### PR TITLE
Add ability to set default settings

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/ConverterTask.java
+++ b/src/main/java/com/glencoesoftware/convert/ConverterTask.java
@@ -120,7 +120,7 @@ class ConverterTask extends Task<Integer> {
                 job.status = COMPLETED;
                 LOGGER.info("Successfully created: " + job.fileOut.getName() + "\n");
             } else if (result == 0) {
-                job.status = NOOUTPUT;
+                job.status = NO_OUTPUT;
                 LOGGER.warn("Job completed but no output detected: " + job.fileOut.getName() + "\n");
             } else if (result == 9) {
                 job.status = FAILED;

--- a/src/main/java/com/glencoesoftware/convert/FileCell.java
+++ b/src/main/java/com/glencoesoftware/convert/FileCell.java
@@ -107,7 +107,7 @@ public class FileCell extends ListCell<IOPackage> {
                     monitor.setGraphic(progress);
                     progress.setTooltip(new Tooltip("Running"));
                 }
-                case NOOUTPUT -> {
+                case NO_OUTPUT -> {
                     monitor.setGraphic(notOk);
                     monitor.setTooltip(new Tooltip("Run completed with no output"));
                 }

--- a/src/main/resources/com/glencoesoftware/convert/primary.fxml
+++ b/src/main/resources/com/glencoesoftware/convert/primary.fxml
@@ -34,6 +34,8 @@
             <MenuItem fx:id="menuRemoveFile" mnemonicParsing="false" onAction="#removeFile" text="Remove Selected" />
             <MenuItem fx:id="menuClearFinished" mnemonicParsing="false" onAction="#clearFinished" text="Clear Finished" />
             <MenuItem fx:id="menuClearAll" mnemonicParsing="false" onAction="#clearFiles" text="Clear All" />
+            <MenuItem fx:id="menuSavePrefs" mnemonicParsing="false" onAction="#savePrefs" text="Save settings as defaults" />
+            <MenuItem fx:id="menuResetPrefs" mnemonicParsing="false" onAction="#resetPrefs" text="Clear saved settings" />
          </Menu>
          <Menu mnemonicParsing="false" text="View">
             <Menu fx:id="menuLogLevel" mnemonicParsing="false" text="Log Level" />


### PR DESCRIPTION
Resolves #18 

This PR introduces a system for changing default app settings. The Edit menu now has options to save and clear a set of defaults based on what's currently selected in the UI.

The preserved settings should be those from the main GUI - target format, log level, whether to overwrite, extra params and the output folder. Any saved settings should get loaded automatically when starting NGFF Converter