### PR TITLE
Add ability to split series into individual tiffs.

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/App.java
+++ b/src/main/java/com/glencoesoftware/convert/App.java
@@ -21,6 +21,7 @@ public class App extends Application {
     @Override
     public void start(Stage stage) throws IOException {
         scene = new Scene(loadFXML("primary"), 800, 550);
+        scene.getStylesheets().add(Objects.requireNonNull(getClass().getResource("style.css")).toExternalForm());
         stage.setScene(scene);
         stage.setTitle("NGFF Converter");
         Image icon = new Image(Objects.requireNonNull(getClass().getResourceAsStream("main-icon.png")));

--- a/src/main/java/com/glencoesoftware/convert/ConverterTask.java
+++ b/src/main/java/com/glencoesoftware/convert/ConverterTask.java
@@ -7,6 +7,14 @@ import javafx.application.Platform;
 import javafx.concurrent.Task;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
+import loci.common.services.DependencyException;
+import loci.common.services.ServiceException;
+import loci.common.services.ServiceFactory;
+import loci.formats.FormatException;
+import loci.formats.IFormatReader;
+import loci.formats.ImageReader;
+import loci.formats.meta.IMetadata;
+import loci.formats.services.OMEXMLService;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -15,6 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.glencoesoftware.convert.PrimaryController.jobStatus.*;
 
@@ -23,6 +33,7 @@ class ConverterTask extends Task<Integer> {
     private final ListView<IOPackage> inputFileList;
     private final Label statusBox;
     private final PrimaryController parent;
+    private final boolean splitSeries;
     public boolean interrupted;
     private static final ch.qos.logback.classic.Logger LOGGER =
             (ch.qos.logback.classic.Logger)LoggerFactory.getLogger(ConverterTask.class);
@@ -33,11 +44,12 @@ class ConverterTask extends Task<Integer> {
         this.args = args;
         this.inputFileList = parent.inputFileList;
         this.statusBox = parent.statusBox;
+        this.splitSeries = parent.wantSplit.isSelected();
         this.interrupted = false;
     }
 
     @Override
-    protected Integer call() throws IOException {
+    protected Integer call() throws IOException, ServiceException, DependencyException, FormatException {
         RunnerParameterExceptionHandler paramHandler = new RunnerParameterExceptionHandler();
         RunnerExecutionExceptionHandler runHandler = new RunnerExecutionExceptionHandler();
         int count = 0;
@@ -58,65 +70,96 @@ class ConverterTask extends Task<Integer> {
                 inputFileList.refresh();
             });
 
-            ArrayList<String> params;
-            if (job.outputMode == PrimaryController.OutputMode.TIFF) {
-                LOGGER.info("Will convert to NGFF first");
-                String temporaryStorage;
-                if (parent.tempDirectory != null) {
-                    temporaryStorage = parent.tempDirectory.getAbsolutePath();
+            List<Integer> subJobs = List.of(-1);
+            int numSeries = 0;
+            if (job.outputMode == PrimaryController.OutputMode.TIFF &&
+                    this.splitSeries && !in.getAbsolutePath().endsWith(".zarr")) {
+                numSeries = getSeriesCount(in.getAbsolutePath());
+                subJobs = IntStream.range(0, numSeries).boxed().collect(Collectors.toList());
+            }
+            File destFile = job.fileOut;
+            int result = -1;
+            for (Integer seriesIdx : subJobs) {
+                if (this.interrupted) { continue; }
+                if (numSeries > 1) {
+                    // Show progress by series, but don't move to 'Done' status.
+                    job.progress = Math.min((seriesIdx + 1.0 / numSeries), 0.99);
+                }
+                Platform.runLater(inputFileList::refresh);
+                ArrayList<String> params;
+                if (job.outputMode == PrimaryController.OutputMode.TIFF) {
+                    LOGGER.info("Will convert to NGFF first");
+                    String temporaryStorage;
+                    if (parent.tempDirectory != null) {
+                        temporaryStorage = parent.tempDirectory.getAbsolutePath();
+                    } else {
+                        temporaryStorage = job.fileOut.getParent();
+                    }
+                    out = new File(Paths.get(temporaryStorage, UUID.randomUUID() + ".zarr").toString());
+                    Set<String> validArgs = runner.getCommandSpec().optionsMap().keySet();
+                    List<String> argsToUse = args.stream().filter(
+                            (arg) -> validArgs.contains(arg.split("=")[0])).toList();
+                    params = new ArrayList<>(argsToUse);
                 } else {
-                    temporaryStorage = job.fileOut.getParent();
+                    out = job.fileOut;
+                    params = new ArrayList<>(args);
                 }
-                out = new File(Paths.get(temporaryStorage, UUID.randomUUID() + ".zarr").toString());
-                Set<String> validArgs = runner.getCommandSpec().optionsMap().keySet();
-                List<String> argsToUse = args.stream().filter(
-                        (arg) -> validArgs.contains(arg.split("=")[0])).toList();
-                params = new ArrayList<>(argsToUse);
-            } else {
-                out = job.fileOut;
-                params = new ArrayList<>(args);
-            }
 
-            // Construct args list
-            params.add(0, out.getAbsolutePath());
-            params.add(0, in.getAbsolutePath());
-            String[] fullParams = params.toArray(new String[args.size()]);
+                // Construct args list
+                params.add(0, out.getAbsolutePath());
+                params.add(0, in.getAbsolutePath());
 
-
-            int result;
-            if (in.getAbsolutePath().endsWith(".zarr")) {
-                // Input file is already a zarr, no need to run Phase 1.
-                result = 0;
-                out = job.fileIn;
-            } else {
-                LOGGER.info("Executing bioformats2raw with args " + Arrays.toString(fullParams));
-                result = runner.execute(fullParams);
-            }
-
-            if (result == 0 && job.outputMode == PrimaryController.OutputMode.TIFF)  {
-                LOGGER.info("NGFF intermediate generated, converting to TIFF");
-                CommandLine converter = new CommandLine(new PyramidFromDirectoryWriter());
-                converter.setParameterExceptionHandler(paramHandler);
-                converter.setExecutionExceptionHandler(runHandler);
-                Set<String> validConverterArgs = converter.getCommandSpec().optionsMap().keySet();
-                List<String> convertArgs = args.stream().filter(
-                        (arg) -> validConverterArgs.contains(arg.split("=")[0])).toList();
-                ArrayList<String> convertParams = new ArrayList<>(convertArgs);
-                convertParams.add(0, job.fileOut.getAbsolutePath());
-                convertParams.add(0, out.getAbsolutePath());
-                String[] phase2Params = convertParams.toArray(new String[0]);
-                LOGGER.info("Executing raw2ometiff with args " + Arrays.toString(phase2Params));
-                result = converter.execute(phase2Params);
-                LOGGER.info("Cleaning up intermediate files");
-                if (out != job.fileIn) {
-                    FileUtils.deleteDirectory(out);
+                if (seriesIdx != -1) {
+                    LOGGER.info("Working on series " + seriesIdx);
+                    params.add("--series=" + seriesIdx);
+                    String outName = job.fileOut.getName();
+                    String outDir = job.fileOut.getParent();
+                    int insertionIndex = outName.toLowerCase().indexOf(".ome.tif");
+                    outName = new StringBuilder(outName).insert(insertionIndex, "_" + seriesIdx).toString();
+                    destFile = new File(outDir, outName);
+                    LOGGER.info("Output file will be " + destFile.getName());
                 }
-            }
 
+                String[] fullParams = params.toArray(new String[args.size()]);
+
+                if (in.getAbsolutePath().endsWith(".zarr")) {
+                    // Input file is already a zarr, no need to run Phase 1.
+                    result = 0;
+                    out = job.fileIn;
+                } else {
+                    LOGGER.info("Executing bioformats2raw with args " + Arrays.toString(fullParams));
+                    result = runner.execute(fullParams);
+                }
+
+                if (result == 0 && job.outputMode == PrimaryController.OutputMode.TIFF)  {
+
+                    LOGGER.info("NGFF intermediate generated, converting to TIFF");
+                    CommandLine converter = new CommandLine(new PyramidFromDirectoryWriter());
+                    converter.setParameterExceptionHandler(paramHandler);
+                    converter.setExecutionExceptionHandler(runHandler);
+                    Set<String> validConverterArgs = converter.getCommandSpec().optionsMap().keySet();
+                    List<String> convertArgs = args.stream().filter(
+                            (arg) -> validConverterArgs.contains(arg.split("=")[0])).toList();
+                    ArrayList<String> convertParams = new ArrayList<>(convertArgs);
+                    convertParams.add(0, destFile.getAbsolutePath());
+                    convertParams.add(0, out.getAbsolutePath());
+                    String[] phase2Params = convertParams.toArray(new String[0]);
+                    LOGGER.info("Executing raw2ometiff with args " + Arrays.toString(phase2Params));
+                    result = converter.execute(phase2Params);
+                    LOGGER.info("Cleaning up intermediate files");
+                    if (out != job.fileIn) {
+                        FileUtils.deleteDirectory(out);
+                    }
+                }
+                if (result != 0) {
+                    break;
+                }
+
+            }
             if (this.interrupted && result != 0) {
                 job.status = FAILED;
                 LOGGER.info("User aborted job: " + job.fileOut.getName() + "\n");
-            } else if (result == 0 && job.fileOut.exists()) {
+            } else if (result == 0 && destFile.exists()) {
                 job.status = COMPLETED;
                 LOGGER.info("Successfully created: " + job.fileOut.getName() + "\n");
             } else if (result == 0) {
@@ -141,6 +184,19 @@ class ConverterTask extends Task<Integer> {
             parent.runCompleted();
         });
         return 0;
+    }
+
+    private Integer getSeriesCount(String filename) throws IOException, FormatException, DependencyException,
+            ServiceException {
+        ServiceFactory factory = new ServiceFactory();
+        OMEXMLService service = factory.getInstance(OMEXMLService.class);
+        IMetadata meta = service.createOMEXMLMetadata();
+        // Create reader object
+        IFormatReader reader = new ImageReader();
+        reader.setFlattenedResolutions(false);
+        reader.setMetadataStore(meta);
+        reader.setId(filename);
+        return reader.getSeriesCount();
     }
 
     private static class RunnerExecutionExceptionHandler implements CommandLine.IExecutionExceptionHandler {

--- a/src/main/java/com/glencoesoftware/convert/FileCell.java
+++ b/src/main/java/com/glencoesoftware/convert/FileCell.java
@@ -106,6 +106,14 @@ public class FileCell extends ListCell<IOPackage> {
                 case RUNNING -> {
                     monitor.setGraphic(progress);
                     progress.setTooltip(new Tooltip("Running"));
+                    if (pack.progress != null) {
+                        progress.setProgress(pack.progress);
+                        // JavaFX is annoying, the % text label only exists when in finite mode and, even if made
+                        // invisible via CSS, still takes up space. To solve this we adjust padding.
+                        progress.setStyle("-fx-padding: 0 0 -32 0;");
+                    } else {
+                        progress.setStyle("");
+                    }
                 }
                 case NO_OUTPUT -> {
                     monitor.setGraphic(notOk);

--- a/src/main/java/com/glencoesoftware/convert/IOPackage.java
+++ b/src/main/java/com/glencoesoftware/convert/IOPackage.java
@@ -7,11 +7,13 @@ public class IOPackage {
     public File fileOut;
     public PrimaryController.jobStatus status;
     public PrimaryController.OutputMode outputMode;
+    public Double progress;
 
     public IOPackage(File in, File out, boolean overwrite, PrimaryController.OutputMode mode) {
         outputMode = mode;
         fileIn = in;
         fileOut = out;
+        progress = null;
         if (fileOut.exists() && !overwrite) {
             status = PrimaryController.jobStatus.ERROR;
         } else {

--- a/src/main/resources/com/glencoesoftware/convert/primary.fxml
+++ b/src/main/resources/com/glencoesoftware/convert/primary.fxml
@@ -23,6 +23,7 @@
             <MenuItem fx:id="menuRun" mnemonicParsing="false" onAction="#runConvert" text="Run Conversions" />
             <Menu fx:id="menuOutputFormat" mnemonicParsing="false" text="Set output format" />
             <CheckMenuItem fx:id="menuOverwrite" mnemonicParsing="false" onAction="#overwriteMenu" text="Overwrite existing files" />
+            <CheckMenuItem fx:id="menuSplit" mnemonicParsing="false" onAction="#splitMenu" text="Split series into single files" />
             <CheckMenuItem fx:id="wantLogToFile" mnemonicParsing="false" onAction="#toggleFileLogging" text="Log to file" />
             <MenuItem fx:id="menuChooseDirectory" mnemonicParsing="false" onAction="#chooseOutputDirectory" text="Choose Output Directory" />
             <MenuItem fx:id="menuResetDirectory" mnemonicParsing="false" onAction="#resetOutputDirectory" text="Reset Output Directory" />
@@ -150,12 +151,13 @@
                <Font size="15.0" />
             </font>
          </Button>
-         <GridPane minHeight="105.0" prefHeight="105.0" prefWidth="160.0" VBox.vgrow="NEVER">
+         <GridPane minHeight="105.0" prefHeight="120.0" prefWidth="160.0" VBox.vgrow="NEVER">
             <columnConstraints>
                <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="129.0" minWidth="10.0" prefWidth="60.0" />
                <ColumnConstraints halignment="CENTER" hgrow="SOMETIMES" maxWidth="132.0" minWidth="10.0" prefWidth="96.0" />
             </columnConstraints>
             <rowConstraints>
+               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="NEVER" />
@@ -180,6 +182,8 @@
                   <Insets bottom="5.0" left="5.0" right="2.0" top="5.0" />
                </GridPane.margin>
             </ChoiceBox>
+            <Label alignment="CENTER_RIGHT" layoutX="12.0" layoutY="72.0" prefHeight="17.0" prefWidth="81.0" text="Split series" GridPane.rowIndex="3" />
+            <CheckBox fx:id="wantSplit" layoutX="112.0" layoutY="72.0" mnemonicParsing="false" onAction="#toggleSplit" GridPane.columnIndex="1" GridPane.rowIndex="3" />
          </GridPane>
    
                   <VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS">

--- a/src/main/resources/com/glencoesoftware/convert/style.css
+++ b/src/main/resources/com/glencoesoftware/convert/style.css
@@ -1,0 +1,3 @@
+.progress-indicator .percentage {
+    -fx-fill:null;
+}


### PR DESCRIPTION
Needs testing on MacOS, but this should add an additional option to the main settings panel to split input files into individual .tiffs per series when running in OME-TIFF mode. The selected output file name will have `_{seriesNumber}` appended to it during writing.

In theory this should provide a pathway towards producing more sensibly sized ome.tiff files when working with HCS datasets.