### PR TITLE
Update components version of NGFF-Converter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ plugins {
 }
 
 version = '1.0.4'
-String bfversion = "6.8.0"
-String b2rversion = "0.4.0"
-String r2oversion = "0.3.1-rc1"
+String bfversion = "6.10.1"
+String b2rversion = "0.5.0"
+String r2oversion = "0.3.1"
 
 mainClassName = 'com.glencoesoftware.convert.Launcher'
 applicationName = 'NGFF-Converter'
@@ -20,7 +20,7 @@ repositories {
         url 'https://repo.glencoesoftware.com/repository/bioformats2raw2ometiff/'
     }
     maven {
-        url 'https://repo.glencoesoftware.com/repository/jzarr-snapshots'
+        url 'https://nexus.senbox.net/nexus/content/groups/public/'
     }
     maven {
         url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases/'


### PR DESCRIPTION
- Bump bioformat2raw and raw2ometiff version to the latest releases - see https://github.com/glencoesoftware/bioformats2raw/releases/tag/v0.5.0 and https://github.com/glencoesoftware/raw2ometiff/releases/tag/v0.3.1
- Bump Bio-Formats version to 6.10.1
- Use nexus.senbox.net for the release jzarr artifacts