### PR TITLE
Do not bundle all runtime dependencies when packaging the JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,9 +64,7 @@ jar {
                 'Implementation-Version': archiveVersion,
                 'Main-Class': mainClassName
     }
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
+
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 


### PR DESCRIPTION
The current configuration effectively creates an uberJAR in addition to shipping all the Java dependencies as standalone JARs in the libraries directory.

Since the signing process needs to iterate over all the JARs to unpack and sign them, there is no benefit of using a single JAR rather than shipping all the individual component strategy anyways. With this commit, the NGFF-Converter JAR created by the build system should be restricted to only include the classes defined in this source code repository.

Tested locally on OSX by running `./gradlew build` and `./gradlew jpackageImage`.

The packaged artifacts built by the GitHub actions workflows should be tested both on Windows and OSX. With this PR included, I would expect  a significant size reduction of the packages (by ~50%) while all functionalities of the converter should remain identical.