### PR TITLE
Bump logback to version 1.4.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,9 +64,7 @@ jar {
                 'Implementation-Version': archiveVersion,
                 'Main-Class': mainClassName
     }
-    from {
-        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
+
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -46,9 +46,9 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
     implementation 'org.kordamp.ikonli:ikonli-javafx:12.3.0'
     implementation 'org.kordamp.ikonli:ikonli-bootstrapicons-pack:12.3.0'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.7'
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.1.7'
-    implementation group: 'ch.qos.logback', name: 'logback-access', version: '1.1.7'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.4'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.4.4'
+    implementation group: 'ch.qos.logback', name: 'logback-access', version: '1.4.4'
     runtimeOnly "org.openjfx:javafx-graphics:$javafx.version:win"
     runtimeOnly "org.openjfx:javafx-graphics:$javafx.version:linux"
     runtimeOnly "org.openjfx:javafx-graphics:$javafx.version:mac"


### PR DESCRIPTION
In the same spirit as https://github.com/glencoesoftware/bioformats2raw/pull/167 and https://github.com/glencoesoftware/raw2ometiff/pull/85, this bumps the version of logback used by the converter tool to the latest available release.
Unlike `bioformats2raw/raw2ometiff` which have a minimal requirement of JDK 8, this repository requires Java 16 minimum as per https://github.com/glencoesoftware/NGFF-Converter/blob/98be8225132d68256ea303459595ddfbda1d4bd5/build.gradle#L33-L34
so logback is bumped to the latest stable release `1.4.4`.

Note that c93395cda373fd3e81e77d799fbee2a88641efc2 is included as part of this PR, otherwise the logback 1.0.4 dependency bundled in the NGFF-Converter uberJAR takes precedence and is being used at runtime. If #29 gets merged, I can update this PR to push the commit away.

With this PR included, running

```
./gradlew build
unzip build/distributions/NGFF-Converter-1.0.4.zip
 ./NGFF-Converter-1.0.4/bin/NGFF-Converter
 ```

should display something along the lines of

```
...
11:06:49,923 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.4.4
...
```




