### PR TITLE
Add mrxs support

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/PrimaryController.java
+++ b/src/main/java/com/glencoesoftware/convert/PrimaryController.java
@@ -142,7 +142,8 @@ public class PrimaryController {
     @FXML
     public void initialize() throws IOException {
         LOGGER.setLevel(Level.DEBUG);
-         supportedExtensions.add("zarr");
+        supportedExtensions.add("zarr");
+        supportedExtensions.add("mrxs");
         menuBar.setUseSystemMenuBar(true);
         inputFileList.setCellFactory(list -> new FileCell());
         FontIcon addIcon = new FontIcon("bi-plus");


### PR DESCRIPTION
MIRAX `.mrxs` files are supported by bioformats2raw rather than bioformats, and so we need to add them to the list of extensions that the GUI will generate tasks from.

This change allows you to drop an .mrxs file in and run conversion jobs on it normally.