### PR TITLE
Shutdown conversions when closed by OS

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/App.java
+++ b/src/main/java/com/glencoesoftware/convert/App.java
@@ -24,10 +24,14 @@ import java.util.Objects;
 public class App extends Application {
 
     private static Scene scene;
+    private static PrimaryController controller;
 
     @Override
     public void start(Stage stage) throws IOException {
-        scene = new Scene(loadFXML("primary"), 800, 550);
+        FXMLLoader fxmlLoader = new FXMLLoader(App.class.getResource("primary.fxml"));
+        Parent primary = fxmlLoader.load();
+        scene = new Scene(primary, 800, 550);
+        controller = fxmlLoader.getController();
         stage.setScene(scene);
         stage.setTitle("NGFF Converter");
         Image icon = new Image(Objects.requireNonNull(getClass().getResourceAsStream("main-icon.png")));
@@ -36,17 +40,15 @@ public class App extends Application {
         stage.show();
     }
 
-    static void setRoot(String fxml) throws IOException {
-        scene.setRoot(loadFXML(fxml));
+    @Override
+    public void stop() throws InterruptedException {
+        if (controller.isRunning) {
+            controller.runCancel();
+        }
     }
 
     public static Scene getScene() {
         return scene;
-    }
-
-    private static Parent loadFXML(String fxml) throws IOException {
-        FXMLLoader fxmlLoader = new FXMLLoader(App.class.getResource(fxml + ".fxml"));
-        return fxmlLoader.load();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/glencoesoftware/convert/PrimaryController.java
+++ b/src/main/java/com/glencoesoftware/convert/PrimaryController.java
@@ -99,7 +99,7 @@ public class PrimaryController {
     private Stage r2oHelpWindow;
     public TextArea logBox;
     public Button logFileButton;
-    private boolean isRunning = false;
+    public boolean isRunning = false;
     private Thread runnerThread;
     private ConverterTask currentJob;
     private ArrayList<Control> fileControlButtons;
@@ -627,10 +627,7 @@ public class PrimaryController {
     }
 
     @FXML
-    public void onExit() throws InterruptedException {
-        if (isRunning) {
-            runCancel();
-        }
+    public void onExit() {
         Platform.exit();
     }
 


### PR DESCRIPTION
Hopefully fixes #32

Turns out Windows 'X' directly closes the stage without going through the controller. MacOS might be similar but it's easier to replicate on Windows.

To fix this I've kept a record of the controller in the main app so that we can shut down cleanly when the system-level exit command is received. I've also cleaned up/simplified App.java a bit.

There might be better ways to solve this, so ideas are appreciated. We also might want to do some more cleanup on cancelled jobs. Right now any partially converted zarr is probably left on the disk.