### PR TITLE
Switch to app image to aid code signing workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,16 +43,22 @@ jobs:
       name: Download blosc
       run: |
         c:\msys64\usr\bin\wget.exe 'https://github.com/glencoesoftware/c-blosc-windows-x86_64/releases/download/20220919/blosc.dll'
-    - name: Run jpackage with Gradle
+    - if: ${{ matrix.os == 'windows-latest' }}
+      name: Run jpackage with Gradle (installer)
       uses: gradle/gradle-build-action@v2
       with:
         arguments: jpackage
+    - if: ${{ matrix.os == 'macos-latest' }}
+      name: Run jpackage with Gradle (application image only)
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: jpackageImage
     - if: ${{ matrix.os == 'macos-latest' }}
       name: Upload Mac pkg
       uses: actions/upload-artifact@v2
       with:
         name: macos-package
-        path: ./build/jpackage/*.pkg
+        path: ./build/jpackage/*.app
         if-no-files-found: error
         retention-days: 3
     - if: ${{ matrix.os == 'windows-latest' }}
@@ -78,6 +84,6 @@ jobs:
         with:
           files: |
             windows-package/*.msi
-            macos-package/*.pkg
+            macos-package/*.app
           draft: true
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.1.1 (2023-01-05)
+
+## Bugfixes/Maintenance:
+* Switch to app image to aid code signing workflow (#36).
+
 # v1.1.0 (2022-12-15)
 
 ## Features:
@@ -10,7 +15,6 @@
 * Fixed an issue which could prevent running conversions from stopping upon exit (#33).
 * Improvements to the build/packaging system. Application filesize should now be much smaller (#29, #24).
 * UI tweaks (#28)
-
 
 # v1.0.3 (2022-09-16)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.beryx.runtime' version '1.12.5'
 }
 
-version = '1.1.0'
+version = '1.1.1'
 String bfversion = "6.11.1"
 String b2rversion = "0.6.0"
 String r2oversion = "0.4.0"

--- a/build.gradle
+++ b/build.gradle
@@ -136,9 +136,7 @@ runtime {
             installerOptions += ['--linux-package-name', applicationName,'--linux-shortcut']
         }
         else if (currentOs.macOsX) {
-            installerType = "pkg"
             imageOptions += ['--java-options', '-Djava.library.path=../lib']
-            installerOptions += ['--mac-package-name', applicationName]
         }
     }
 }


### PR DESCRIPTION
A `.pkg` "installer" just complicates the downstream code signing workflow so we can just create the application image as part of the build process. Signing and notarization of the application and installers will happen separately.