### PR TITLE
Remove year from Copyright in About window

### DIFF
--- a/src/main/resources/com/glencoesoftware/convert/AboutDialog.fxml
+++ b/src/main/resources/com/glencoesoftware/convert/AboutDialog.fxml
@@ -31,7 +31,7 @@
    <Label text="${'bioformats2raw - ' + b2rVer}"/>
    <Label text="${'raw2ometiff - ' + r2oVer}"/>
    <Label text="${'Bio-Formats - ' + bfVer}"/>
-   <Label text="Copyright © 2022 Glencoe Software">
+   <Label text="Copyright © Glencoe Software">
       <VBox.margin>
          <Insets top="10.0"/>
       </VBox.margin>


### PR DESCRIPTION
Reported by @erindiel, the year in the About window is outdated. 
<img width="868" alt="Screenshot 2023-01-09 at 19 12 58" src="https://user-images.githubusercontent.com/1355463/211388923-d94b473a-33f1-4ba2-a68c-8548e69a72ca.png">

Rather than updating or dynamically storing either the build or the current year, this PR proposes to remove altogether the year from the Copyright line in this window. This follows recommendations from various authoritative projects like the [Linux Foundation](https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects)  and removes the requirement to periodically update these.

