### PR TITLE
Add dependency report generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,11 @@ jobs:
       with:
         arguments: jpackageImageZip
     - if: ${{ matrix.os == 'macos-latest' }}
+      name: Generate dependency report
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: downloadLicenses
+    - if: ${{ matrix.os == 'macos-latest' }}
       name: Upload Mac pkg
       uses: actions/upload-artifact@v2
       with:
@@ -67,6 +72,14 @@ jobs:
       with:
         name: windows-package
         path: ./build/jpackage/*.msi
+        if-no-files-found: error
+        retention-days: 3
+    - if: ${{ matrix.os == 'macos-latest' }}
+      name: Upload Mac pkg
+      uses: actions/upload-artifact@v2
+      with:
+        name: dependency-report
+        path: ./build/reports/license/dependency-license*
         if-no-files-found: error
         retention-days: 3
   upload:
@@ -85,5 +98,6 @@ jobs:
           files: |
             windows-package/*.msi
             macos-package/*.zip
+            dependency-report/*
           draft: true
           fail_on_unmatched_files: true

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.10'
     id 'org.beryx.runtime' version '1.12.5'
+    id "com.github.hierynomus.license" version "0.16.1"
 }
 
 version = '1.1.5'
@@ -141,4 +142,27 @@ runtime {
         dependsOn jpackageImage
         from layout.buildDirectory.dir("jpackage")
     }
+}
+
+downloadLicenses {
+    includeProjectDependencies = true
+    dependencyConfiguration = 'runtimeClasspath'
+    licenses = [
+        // See https://github.com/Unidata/netcdf-java/blob/v5.3.3/LICENSE
+        (group('edu.ucar')): license('The 3-Clause BSD License', 'https://opensource.org/license/bsd-3-clause/'),
+        // See https://github.com/openjdk/jfx/blob/17%2B2/LICENSE
+        (group('org.openjfx')): license('GNU General Public License version 2 with Classpath Exception', 'https://openjdk.org/legal/gplv2+ce.html'),
+        // See https://github.com/javaee/jaxb-v2/blob/2.3.0/LICENSE
+        (group('javax.xml.bind')): license('Common Development and Distribution License 1.1 and GNU General Public License version 2 with Classpath Exception', 'https://oss.oracle.com/licenses/CDDL+GPL-1.1'),
+        // See https://github.com/openpnp/opencv/blob/v3.4.2-0/LICENSE
+        (group('org.openpnp')): license('The 3-Clause BSD License', 'https://opensource.org/license/bsd-3-clause/'),
+    ]
+    aliases = [
+        (license('Apache License, Version 2.0', 'http://www.apache.org/licenses/LICENSE-2.0')) : ['The Apache Software License, Version 2.0', 'Apache 2', 'Apache License Version 2.0', 'Apache License 2.0', 'The Apache License, Version 2.0', 'Apache 2.0', 'Apache-2.0'],
+        (license('GNU Lesser General Public License version 2.1', 'https://opensource.org/license/lgpl-2-1/')) : ['GNU Lesser General Public License v2.1+'],
+        (license('GNU General Public License version 2', 'https://opensource.org/license/gpl-2/')) : ['GNU General Public License v2+'],
+        (license('The 2-Clause BSD License', 'https://opensource.org/license/bsd-2-clause/')) : ['Simplified BSD License', 'The BSD License', 'New BSD License'],
+        (license('The 3-Clause BSD License', 'https://opensource.org/license/bsd-3-clause/')) : ['The BSD 3-Clause License (BSD3)', '3-Clause BSD License'],
+        (license('The MIT License', 'https://opensource.org/license/mit/')) : ['MIT License', 'MIT']
+    ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application'
     id 'org.openjfx.javafxplugin' version '0.0.10'
     id 'org.beryx.runtime' version '1.12.5'
-    id "com.github.hierynomus.license" version "0.16.1"
+    id "com.github.hierynomus.license-report" version "0.16.1"
 }
 
 version = '1.1.5'


### PR DESCRIPTION
This adds the build logic to generate a report of all dependencies of the NGFF-Converter application including their licenses similar to the effort done for https://www.glencoesoftware.com/products/omeroplus/dependencies/

- add `build.gradle` target consuming https://github.com/hierynomus/license-gradle-plugin
- override and normalize dependencies as 
- add the dependency report generation to the GitHub workflow build process

A new build artifact should be generated including the dependency report in various formats (XML, JSON, HTML) for inspection. The current version of the dependencies include a few `No license found` statements but this should be addressed when we consume the upcoming releases of `bioformats2raw` and `raw2ometiff`