### PR TITLE
Add "-Dprism.order=sw" to default options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,3 +146,7 @@ runtime {
         from layout.buildDirectory.dir("jpackage")
     }
 }
+
+startScripts {
+    applicationDefaultJvmArgs = ["-Dprism.order=sw"]
+}


### PR DESCRIPTION
Fixes blank dialogs on Windows. See https://wiki.openjdk.org/display/OpenJFX/Debug+Flags for as description of `prism.order`.

I was trying to test job/workflow cancellation on Windows with v2, and found all dialogs except the two "Help" ones were entirely blank without this change.

Building with this PR should add `-Dprism.order=sw` to `DEFAULT_JVM_OPTS` in both `bin/NGFF-Converter` and `bin/NGFF-Converter.bat`. If only the .bat file should be changed, then this PR would need some modifications.
