### PR TITLE
Add download button to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ With default settings, the resulting files should automatically have resolution 
 
 ## Prebuilt Binaries
 
-Download NGFF-Converter using the following link
+NGFF-Converter releases can be downloaded here:
 
 <img src="https://img.shields.io/badge/Downloads_Page-2980B8?style=flat" height="35"  alt="Downloads Page"/>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ With default settings, the resulting files should automatically have resolution 
 
 NGFF-Converter releases can be downloaded here:
 
-<img src="https://img.shields.io/badge/Downloads_Page-2980B8?style=flat" height="35"  alt="Downloads Page"/>
+[<img src="https://img.shields.io/badge/Downloads_Page-2980B8?style=flat" height="35"  alt="Downloads Page"/>](https://downloads.glencoesoftware.com/public/NGFF-Converter/latest/)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Formats [supported by the bio-formats library](https://bio-formats.readthedocs.i
 Internally NGFF-Converter uses the [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) and [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff) packages for conversion.
 With default settings, the resulting files should automatically have resolution pyramids generated if needed.
 
+## Prebuilt Binaries
+
+Download NGFF-Converter using the following link
+
+<img src="https://img.shields.io/badge/Downloads_Page-2980B8?style=flat" height="35"  alt="Downloads Page"/>
+
 ## Usage
 
 Running the tool will display a desktop GUI:


### PR DESCRIPTION
Per @will-moore's suggestion, this PR adds a distinctive button to the readme linking to the proper downloads page. Unsigned builds can be found on the releases page, so it's a good idea to provide users with direction to the proper source of signed binaries.