### PR TITLE
Bump version and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v2.0.1 (2024-05-02)
+
+### Bugfixes/Maintenance:
+* Updated component package versions
+  * bioformats 7.2.0
+  * bioformats2raw 0.9.2
+* Fixed a bug when trying to open a deleted image
+* Custom directories which do not exist will now be created when saving task settings
+
+### Known issues:
+* The underlying bioformats package is currently unable to read some formats on ARM-based MacOS systems.
+* raw2ometiff execution cannot be reliably interrupted until it finishes the initial scan of a .zarr file.
+
 # v2.0.0 (2024-02-16)
 
 ### Features:

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ plugins {
     id "com.github.hierynomus.license-report" version "0.16.1"
 }
 
-version = '2.0.0'
-String bfversion = "7.1.0"
-String b2rversion = "0.9.1"
+version = '2.0.1'
+String bfversion = "7.2.0"
+String b2rversion = "0.9.2"
 String r2oversion = "0.7.0"
 
 mainClassName = 'com.glencoesoftware.convert.Launcher'
@@ -49,9 +49,9 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
     implementation 'org.kordamp.ikonli:ikonli-javafx:12.3.0'
     implementation 'org.kordamp.ikonli:ikonli-bootstrapicons-pack:12.3.0'
-    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.4'
-    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.4.4'
-    implementation group: 'ch.qos.logback', name: 'logback-access', version: '1.4.4'
+    implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.4.12'
+    implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.4.12'
+    implementation group: 'ch.qos.logback', name: 'logback-access', version: '1.4.12'
     implementation group: 'org.controlsfx', name: 'controlsfx', version: '11.1.2'
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     runtimeOnly "org.openjfx:javafx-graphics:$javafx.version:win"


### PR DESCRIPTION
Bumps version to v2.0.1, should include #60, #62 and #63

Have updated dependencies, including logback since there was a security advisory.