### PR TITLE
Fix OMERO metadata calculation setting

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -261,7 +261,7 @@ public class CreateNGFF extends BaseTask{
 
         if (!maxCachedTiles.getText().isEmpty()) converter.setMaxCachedTiles(
                 Integer.parseInt(maxCachedTiles.getText()));
-        converter.setCalculateOMEROMetadata(disableMinMax.isSelected());
+        converter.setCalculateOMEROMetadata(!disableMinMax.isSelected());
         converter.setNoHCS(disableHCS.isSelected());
 
         converter.setUnnested(!nested.isSelected());
@@ -323,7 +323,7 @@ public class CreateNGFF extends BaseTask{
         converter.setFillValue(source.converter.getFillValue());
         converter.setCompressionProperties(source.converter.getCompressionProperties());
         converter.setMaxCachedTiles(source.converter.getMaxCachedTiles());
-        converter.setCalculateOMEROMetadata(source.converter.getCalculateOMEROMetadata());
+        converter.setCalculateOMEROMetadata(!source.converter.getCalculateOMEROMetadata());
         converter.setNoHCS(source.converter.getNoHCS());
         converter.setUnnested(!source.converter.getNested());
         converter.setNoOriginalMetadata(!source.converter.getOriginalMetadata());
@@ -968,7 +968,7 @@ public class CreateNGFF extends BaseTask{
         converter.setMaxCachedTiles(taskPreferences.getInt(prefKeys.MAX_CACHED_TILES.name(),
                 converter.getMaxCachedTiles()));
 
-        converter.setCalculateOMEROMetadata(taskPreferences.getBoolean(
+        converter.setCalculateOMEROMetadata(!taskPreferences.getBoolean(
                 prefKeys.MIN_MAX.name(), converter.getCalculateOMEROMetadata()));
         converter.setNoHCS(taskPreferences.getBoolean(prefKeys.HCS.name(), converter.getNoHCS()));
         converter.setUnnested(!taskPreferences.getBoolean(prefKeys.NESTED.name(), converter.getNested()));


### PR DESCRIPTION
@sbesson reports (and I can confirm) that toggling the `Calculate min/max values` option on has no effect. Toggling the option on, clicking `Apply`, then viewing settings again shows that `Calculate min/max values` has been reset to off. Conversions as expected then do not include min/max metadata needed for OMERO.

This change should preserve the selected min/max option and pass it through to bioformats2raw. I haven't actually tested this yet, it's just modelled on how `setUnnested(...)` is handled, as those setters behave similarly in bioformats2raw, and we have confirmed that `setUnnested(...)` is working as expected in NGFF-Converter 2.0.2.

See relevant option in bioformats2raw:

https://github.com/glencoesoftware/bioformats2raw/blob/master/src/main/java/com/glencoesoftware/bioformats2raw/Converter.java#L606
