### PR TITLE
Fix tooltip on the start button

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/tables/MultiButtonTableCell.java
+++ b/src/main/java/com/glencoesoftware/convert/tables/MultiButtonTableCell.java
@@ -76,9 +76,9 @@ public class MultiButtonTableCell extends TableCell<BaseWorkflow, Void> {
         removeJobDisabled.setTooltip(new Tooltip("Job is already stopping"));
 
         startJob.setGraphic(startJobIcon);
-        startJob.setTooltip(new Tooltip("Stop execution"));
+        startJob.setTooltip(new Tooltip("Start execution"));
         startJob.setOnAction(evt -> {
-            // Stop an ongoing run
+            // Add a job to the queue
             BaseWorkflow subject = getTableRow().getItem();
             if (subject.canRun()) subject.queueJob();
             subject.controller.updateStatus("Queued " + subject.firstInput.getName());


### PR DESCRIPTION
Noticed while looking at #76 (but not introduced by that PR):

<img width="1282" height="789" alt="image" src="https://github.com/user-attachments/assets/629a2ba7-5232-4bc4-b015-5d1585343e8c" />

The start button behaves correctly, but the tooltip incorrectly shows `Stop execution` before the job is started.

This change should fix the tooltip and inline comment to match the start button's action.