### PR TITLE
Prevent double opening of license link

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/dialogs/AboutDialog.java
+++ b/src/main/java/com/glencoesoftware/convert/dialogs/AboutDialog.java
@@ -9,6 +9,7 @@ package com.glencoesoftware.convert.dialogs;
 import com.glencoesoftware.bioformats2raw.Converter;
 import com.glencoesoftware.convert.App;
 import com.glencoesoftware.pyramid.PyramidFromDirectoryWriter;
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import loci.formats.ImageReader;
@@ -37,12 +38,13 @@ public class AboutDialog {
     }
 
     @FXML
-    public void licenseLink() {
+    public void licenseLink(ActionEvent event) {
         try {
             Desktop.getDesktop().browse(
                     new URI("https://github.com/glencoesoftware/NGFF-Converter/blob/main/LICENSE.txt"));
         } catch (IOException | URISyntaxException e) {
             throw new RuntimeException(e);
         }
+        event.consume();
     }
 }


### PR DESCRIPTION
Minor issue discovered during the last testing cycle: In the "About" dialog clicking the GPL license link would open two copies of the web page rather than one.

Turns out that since we use a special hyperlink class from ControlsFX to only show the link on the desired text for that line of the About dialog, we need to prevent the event from being handled by the native JavaFX hyperlink class that was inherited from.