### PR TITLE
Zarr v3/OME-Zarr 0.5 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         distribution: 'temurin'
         architecture: 'x64'
     - name: Setup Gradle wrapper
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v6
     - if: ${{ matrix.os == 'macos-latest' }}
       name: Install bundler and download blosc
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ macos-latest, windows-latest ]
@@ -26,11 +28,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v6
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -57,7 +59,7 @@ jobs:
       run: ./gradlew downloadLicenses
     - if: ${{ matrix.os == 'macos-latest' }}
       name: Upload Mac pkg
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: macos-package
         path: ./build/distributions/*.zip
@@ -65,7 +67,7 @@ jobs:
         retention-days: 3
     - if: ${{ matrix.os == 'windows-latest' }}
       name: Upload Windows MSI
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: windows-package
         path: ./build/jpackage/*.msi
@@ -73,28 +75,25 @@ jobs:
         retention-days: 3
     - if: ${{ matrix.os == 'macos-latest' }}
       name: Upload Mac pkg
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: dependency-report
         path: ./build/reports/license/dependency-license*
         if-no-files-found: error
         retention-days: 3
   upload:
+    permissions:
+      contents: write
     name: Create release
     needs: build
     runs-on: ubuntu-latest
     if: startswith(github.ref, 'refs/tags/')
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
       - name: List artifacts
         run: ls -R
       - name: Create release draft
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            windows-package/*.msi
-            macos-package/*.zip
-            dependency-report/*
-          draft: true
-          fail_on_unmatched_files: true
+        run: gh release create --draft --generate-notes "${GITHUB_REF#refs/tags/}" windows-package/*.msi macos-package/*.zip dependency-report/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         submodules: true
     - name: Set up JDK 17
-      uses: actions/setup-java@v6
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ plugins {
 }
 
 version = '2.1.1-SNAPSHOT'
-String bfversion = "8.3.0"
-String b2rversion = "0.11.0"
-String r2oversion = "0.8.0"
+String bfversion = "8.5.0"
+String b2rversion = "0.12.0"
+String r2oversion = "0.10.0"
 
 mainClassName = 'com.glencoesoftware.convert.Launcher'
 applicationName = 'NGFF-Converter'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 version = '2.1.1-SNAPSHOT'
 String bfversion = "8.5.0"
-String b2rversion = "0.12.0"
+String b2rversion = "0.12.1"
 String r2oversion = "0.10.0"
 
 mainClassName = 'com.glencoesoftware.convert.Launcher'

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -182,7 +182,7 @@ public class CreateNGFF extends BaseTask{
         if (compressionProps.containsKey("shuffle")) {
             compressorBloscShuffle.setValue((String) compressionProps.get("shuffle"));
         } else {
-            compressorBloscShuffle.setValue("byteshuffle");
+            compressorBloscShuffle.setValue("shuffle");
         }
         if (compressionProps.containsKey("level")) {
             compressorZlibLevel.setText(String.valueOf(compressionProps.get("level")));
@@ -840,7 +840,7 @@ public class CreateNGFF extends BaseTask{
         );
 
         compressorBloscShuffle = new ChoiceBox<>(FXCollections.observableArrayList(
-                "noshuffle", "byteshuffle", "bitshuffle"));
+                "noshuffle", "shuffle", "bitshuffle"));
         VBox bloscShuffleBox = getSettingContainer(
                 compressorBloscShuffle,
                 "shuffle",
@@ -1116,7 +1116,7 @@ public class CreateNGFF extends BaseTask{
             compressionProps.put("cname", taskPreferences.get(prefKeys.BLOSC_CNAME.name(), "lz4"));
             compressionProps.put("clevel", taskPreferences.getInt(prefKeys.BLOSC_CLEVEL.name(), 5 ));
             compressionProps.put("blocksize", taskPreferences.getInt(prefKeys.BLOSC_BLOCKSIZE.name(), 0));
-            compressionProps.put("shuffle", taskPreferences.get(prefKeys.BLOSC_SHUFFLE.name(), "byteshuffle"));
+            compressionProps.put("shuffle", taskPreferences.get(prefKeys.BLOSC_SHUFFLE.name(), "shuffle"));
         } else if (converter.getCompression() == ZarrCompression.zlib) {
             compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(),1));
         } else if (converter.getCompression() == ZarrCompression.gzip) {

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -289,6 +289,9 @@ public class CreateNGFF extends BaseTask{
         if (!minImageSize.getText().isEmpty()) converter.setMinImageSize(Integer.parseInt(minImageSize.getText()));
         converter.setReuseExistingResolutions(useExistingResolutions.isSelected());
         if (!chunkDepth.getText().isEmpty()) converter.setChunkDepth(Integer.parseInt(chunkDepth.getText()));
+        if (!shardWidth.getText().isEmpty()) converter.setShardWidth(Integer.parseInt(shardWidth.getText()));
+        if (!shardHeight.getText().isEmpty()) converter.setShardHeight(Integer.parseInt(shardHeight.getText()));
+        if (!shardDepth.getText().isEmpty()) converter.setShardDepth(Integer.parseInt(shardDepth.getText()));
         converter.setScaleFormat(scaleFormatString.getText());
         if (scaleFormatCSV.getText() != null && !scaleFormatCSV.getText().isEmpty())
             converter.setAdditionalScaleFormatCSV(Paths.get(scaleFormatCSV.getText()));

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -193,6 +193,9 @@ public class CreateNGFF extends BaseTask{
             compressorGzipLevel.setText("5");
             compressorZstdLevel.setText("5");
         }
+        if (compressionProps.containsKey("checksum")) {
+            checksum.setSelected(Boolean.parseBoolean(String.valueOf(compressionProps.get("checksum"))));
+        }
 
         maxCachedTiles.setText(String.valueOf(converter.getMaxCachedTiles()));
         disableMinMax.setSelected(converter.getCalculateOMEROMetadata());
@@ -1377,6 +1380,11 @@ public class CreateNGFF extends BaseTask{
         subject = settings.get(prefKeys.FILL_VALUE.name());
         if (subject != null) fillValue.setText(subject.textValue());
 
+        subject = settings.get(prefKeys.HCS.name());
+        if (subject != null) {
+            disableHCS.setSelected(subject.booleanValue());
+        }
+
         subject = settings.get(prefKeys.NGFF_VERSION.name());
         if (subject != null) ngffVersion.setValue(SupportedVersions.valueOf(subject.textValue()));
 
@@ -1414,6 +1422,11 @@ public class CreateNGFF extends BaseTask{
         subject = settings.get(prefKeys.ZSTD_LEVEL.name());
         if (subject != null && compressionSetting == ZarrCompression.zstd) {
             compressorZstdLevel.setText(subject.textValue());
+        }
+
+        subject = settings.get(prefKeys.CHECKSUM.name());
+        if (subject != null) {
+            checksum.setSelected(Boolean.parseBoolean(subject.textValue()));
         }
 
         subject = settings.get(prefKeys.MAX_CACHED_TILES.name());

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -134,6 +134,7 @@ public class CreateNGFF extends BaseTask{
 
         // Populate setting values
         logLevel.setValue(converter.getLogLevel());
+        ngffVersion.setValue(converter.getNGFFVersion());
         maxWorkers.setText(String.valueOf(converter.getMaxWorkers()));
         compression.setValue(converter.getCompression());
         tileHeight.setText(String.valueOf(converter.getTileHeight()));
@@ -147,6 +148,9 @@ public class CreateNGFF extends BaseTask{
         minImageSize.setText(String.valueOf(converter.getMinImageSize()));
         useExistingResolutions.setSelected(converter.getReuseExistingResolutions());
         chunkDepth.setText(String.valueOf(converter.getChunkDepth()));
+        shardWidth.setText(String.valueOf(converter.getShardWidth()));
+        shardHeight.setText(String.valueOf(converter.getShardHeight()));
+        shardDepth.setText(String.valueOf(converter.getShardDepth()));
         scaleFormatString.setText(converter.getScaleFormat());
         Path csvPath = converter.getAdditionalScaleFormatCSV();
         if (csvPath == null) {

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -58,7 +58,8 @@ public class CreateNGFF extends BaseTask{
     public enum prefKeys {LOG_LEVEL, MAX_WORKERS, COMPRESSION, TILE_WIDTH, TILE_HEIGHT, RESOLUTIONS, SERIES,
         COMPACT_DIMENSIONS, DIMENSION_ORDER, DOWNSAMPLING, MIN_IMAGE_SIZE, REUSE_RES, CHUNK_DEPTH, NO_TILES,
         SCALE_FORMAT_STRING, SCALE_FORMAT_CSV, FILL_VALUE, BLOSC_CNAME, BLOSC_CLEVEL, BLOSC_BLOCKSIZE, BLOSC_SHUFFLE,
-        ZLIB_LEVEL, CHECKSUM, MAX_CACHED_TILES, CALC_MIN_MAX, HCS, NESTED, OME_META, NO_ROOT, PYRAMID_NAME, KEEP_MEMOS, MEMO_DIR,
+        ZLIB_LEVEL, GZIP_LEVEL, ZSTD_LEVEL, CHECKSUM, MAX_CACHED_TILES, CALC_MIN_MAX, HCS, NESTED, OME_META, NO_ROOT,
+        PYRAMID_NAME, KEEP_MEMOS, MEMO_DIR,
         READER_OPTS, OUTPUT_OPTS, EXTRA_READERS, WRITE_METADATA,
         NGFF_VERSION, SHARD_WIDTH, SHARD_HEIGHT, SHARD_DEPTH
     }
@@ -93,7 +94,7 @@ public class CreateNGFF extends BaseTask{
     private static final TextField compressorBloscClevel;
     private static final TextField compressorBloscBlockSize;
     private static final ChoiceBox<String> compressorBloscShuffle;
-    private static final TextField compressorZlibLevel;
+    private static final TextField compressorLevel;
     private static final ToggleSwitch checksum;
 
     private static final TextField maxCachedTiles;
@@ -181,10 +182,28 @@ public class CreateNGFF extends BaseTask{
         } else {
             compressorBloscShuffle.setValue("byteshuffle");
         }
-        if (compressionProps.containsKey("level")) {
-            compressorZlibLevel.setText(String.valueOf(compressionProps.get("level")));
-        } else {
-            compressorZlibLevel.setText("1");
+        switch (converter.getCompression()) {
+            case zlib:
+                if (compressionProps.containsKey("level")) {
+                    compressorLevel.setText(String.valueOf(compressionProps.get("level")));
+                } else {
+                    compressorLevel.setText("1");
+                }
+                break;
+            case gzip:
+                if (compressionProps.containsKey("level")) {
+                    compressorLevel.setText(String.valueOf(compressionProps.get("level")));
+                } else {
+                    compressorLevel.setText("5");
+                }
+                break;
+            case zstd:
+                if (compressionProps.containsKey("level")) {
+                    compressorLevel.setText(String.valueOf(compressionProps.get("level")));
+                } else {
+                    compressorLevel.setText("5");
+                }
+                break;
         }
 
         maxCachedTiles.setText(String.valueOf(converter.getMaxCachedTiles()));
@@ -837,10 +856,10 @@ public class CreateNGFF extends BaseTask{
                 ""
         );
 
-        compressorZlibLevel = new TextField();
-        compressorZlibLevel.setTextFormatter(new TextFormatter<>(integerFilterSingleDigit));
-        VBox zlibLevelBox = getSettingContainer(
-                compressorZlibLevel,
+        compressorLevel = new TextField();
+        compressorLevel.setTextFormatter(new TextFormatter<>(integerFilterSingleDigit));
+        VBox levelBox = getSettingContainer(
+                compressorLevel,
                 "level",
                 ""
         );
@@ -858,17 +877,17 @@ public class CreateNGFF extends BaseTask{
                             compressionPropertiesBox.setVisible(true);
                         }
                         case zlib -> {
-                            compressionPropertiesBox.getChildren().addAll(compressionTitle, zlibLevelBox,
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, levelBox,
                                     compressionHelpText);
                             compressionPropertiesBox.setVisible(true);
                         }
                         case gzip -> {
-                            compressionPropertiesBox.getChildren().addAll(compressionTitle, zlibLevelBox,
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, levelBox,
                                     compressionHelpText);
                             compressionPropertiesBox.setVisible(true);
                         }
                         case zstd -> {
-                            compressionPropertiesBox.getChildren().addAll(compressionTitle, zlibLevelBox,
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, levelBox,
                                     checksumBox, compressionHelpText);
                             compressionPropertiesBox.setVisible(true);
                         }
@@ -939,16 +958,16 @@ public class CreateNGFF extends BaseTask{
                     compressionProps.put("shuffle", compressorBloscShuffle.getValue());
             }
             case zlib -> {
-                if (compressorZlibLevel.getText() != null)
-                    compressionProps.put("level", Integer.parseInt(compressorZlibLevel.getText()));
+                if (compressorLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorLevel.getText()));
             }
             case gzip -> {
-                if (compressorZlibLevel.getText() != null)
-                    compressionProps.put("level", Integer.parseInt(compressorZlibLevel.getText()));
+                if (compressorLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorLevel.getText()));
             }
             case zstd -> {
-                if (compressorZlibLevel.getText() != null)
-                    compressionProps.put("level", Integer.parseInt(compressorZlibLevel.getText()));
+                if (compressorLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorLevel.getText()));
                 compressionProps.put("checksum", String.valueOf(checksum.isSelected()));
             }
         }
@@ -994,6 +1013,8 @@ public class CreateNGFF extends BaseTask{
         taskPreferences.remove(prefKeys.BLOSC_BLOCKSIZE.name());
         taskPreferences.remove(prefKeys.BLOSC_SHUFFLE.name());
         taskPreferences.remove(prefKeys.ZLIB_LEVEL.name());
+        taskPreferences.remove(prefKeys.GZIP_LEVEL.name());
+        taskPreferences.remove(prefKeys.ZSTD_LEVEL.name());
         if (converter.getCompression() == ZarrCompression.blosc) {
             if (compressionProps.containsKey(prefKeys.BLOSC_CNAME.name()))
                 taskPreferences.put(prefKeys.BLOSC_CNAME.name(), (String) compressionProps.get("cname"));
@@ -1003,15 +1024,20 @@ public class CreateNGFF extends BaseTask{
                 taskPreferences.putInt(prefKeys.BLOSC_BLOCKSIZE.name(), (Integer) compressionProps.get("blocksize"));
             if (compressionProps.containsKey(prefKeys.BLOSC_SHUFFLE.name()))
                 taskPreferences.put(prefKeys.BLOSC_SHUFFLE.name(), (String) compressionProps.get("shuffle"));
-        } else if (converter.getCompression() == ZarrCompression.zlib ||
-            converter.getCompression() == ZarrCompression.gzip)
+        } else if (converter.getCompression() == ZarrCompression.zlib)
         {
             if (compressionProps.containsKey(prefKeys.ZLIB_LEVEL.name())) {
                 taskPreferences.putInt(prefKeys.ZLIB_LEVEL.name(), (Integer) compressionProps.get("level"));
             }
-        } else if (converter.getCompression() == ZarrCompression.zstd) {
-            if (compressionProps.containsKey(prefKeys.ZLIB_LEVEL.name())) {
-                taskPreferences.putInt(prefKeys.ZLIB_LEVEL.name(), (Integer) compressionProps.get("level"));
+        } else if (converter.getCompression() == ZarrCompression.gzip)
+        {
+            if (compressionProps.containsKey(prefKeys.GZIP_LEVEL.name())) {
+                taskPreferences.putInt(prefKeys.GZIP_LEVEL.name(), (Integer) compressionProps.get("level"));
+            }
+        }
+        else if (converter.getCompression() == ZarrCompression.zstd) {
+            if (compressionProps.containsKey(prefKeys.ZSTD_LEVEL.name())) {
+                taskPreferences.putInt(prefKeys.ZSTD_LEVEL.name(), (Integer) compressionProps.get("level"));
             }
             if (compressionProps.containsKey(prefKeys.CHECKSUM.name())) {
                 taskPreferences.put(prefKeys.CHECKSUM.name(), (String) compressionProps.get("checksum"));
@@ -1089,9 +1115,9 @@ public class CreateNGFF extends BaseTask{
         } else if (converter.getCompression() == ZarrCompression.zlib) {
             compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(),1));
         } else if (converter.getCompression() == ZarrCompression.gzip) {
-            compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(), 5));
+            compressionProps.put("level", taskPreferences.getInt(prefKeys.GZIP_LEVEL.name(), 5));
         } else if (converter.getCompression() == ZarrCompression.zstd) {
-            compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(), 5));
+            compressionProps.put("level", taskPreferences.getInt(prefKeys.ZSTD_LEVEL.name(), 5));
             compressionProps.put("checksum", taskPreferences.get(prefKeys.CHECKSUM.name(), "true"));
         }
         converter.setCompressionProperties(compressionProps);
@@ -1236,10 +1262,10 @@ public class CreateNGFF extends BaseTask{
             generator.writeFieldName(prefKeys.ZLIB_LEVEL.name());
             generator.writeString(String.valueOf(compressionProps.get("level")));
         } else if (converter.getCompression() == ZarrCompression.gzip) {
-            generator.writeFieldName(prefKeys.ZLIB_LEVEL.name());
+            generator.writeFieldName(prefKeys.GZIP_LEVEL.name());
             generator.writeString(String.valueOf(compressionProps.get("level")));
         } else if (converter.getCompression() == ZarrCompression.zstd) {
-            generator.writeFieldName(prefKeys.ZLIB_LEVEL.name());
+            generator.writeFieldName(prefKeys.ZSTD_LEVEL.name());
             generator.writeString(String.valueOf(compressionProps.get("level")));
             generator.writeFieldName(prefKeys.CHECKSUM.name());
             generator.writeString(String.valueOf(compressionProps.get("checksum")));
@@ -1301,7 +1327,11 @@ public class CreateNGFF extends BaseTask{
         if (subject != null) maxWorkers.setText(subject.textValue());
 
         subject = settings.get(prefKeys.COMPRESSION.name());
-        if (subject != null) compression.setValue(ZarrCompression.valueOf(subject.textValue()));
+        ZarrCompression compressionSetting = null;
+        if (subject != null) {
+            compressionSetting = ZarrCompression.valueOf(subject.textValue());
+            compression.setValue(compressionSetting);
+        }
 
         subject = settings.get(prefKeys.TILE_WIDTH.name());
         if (subject != null) tileWidth.setText(subject.textValue());
@@ -1367,7 +1397,19 @@ public class CreateNGFF extends BaseTask{
         if (subject != null) compressorBloscShuffle.setValue(subject.textValue());
 
         subject = settings.get(prefKeys.ZLIB_LEVEL.name());
-        if (subject != null) compressorZlibLevel.setText(subject.textValue());
+        if (subject != null && compressionSetting == ZarrCompression.zlib) {
+            compressorLevel.setText(subject.textValue());
+        }
+
+        subject = settings.get(prefKeys.GZIP_LEVEL.name());
+        if (subject != null && compressionSetting == ZarrCompression.gzip) {
+            compressorLevel.setText(subject.textValue());
+        }
+
+        subject = settings.get(prefKeys.ZSTD_LEVEL.name());
+        if (subject != null && compressionSetting == ZarrCompression.zstd) {
+            compressorLevel.setText(subject.textValue());
+        }
 
         subject = settings.get(prefKeys.MAX_CACHED_TILES.name());
         if (subject != null) maxCachedTiles.setText(subject.textValue());

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -58,7 +58,7 @@ public class CreateNGFF extends BaseTask{
     public enum prefKeys {LOG_LEVEL, MAX_WORKERS, COMPRESSION, TILE_WIDTH, TILE_HEIGHT, RESOLUTIONS, SERIES,
         COMPACT_DIMENSIONS, DIMENSION_ORDER, DOWNSAMPLING, MIN_IMAGE_SIZE, REUSE_RES, CHUNK_DEPTH, NO_TILES,
         SCALE_FORMAT_STRING, SCALE_FORMAT_CSV, FILL_VALUE, BLOSC_CNAME, BLOSC_CLEVEL, BLOSC_BLOCKSIZE, BLOSC_SHUFFLE,
-        ZLIB_LEVEL, MAX_CACHED_TILES, CALC_MIN_MAX, HCS, NESTED, OME_META, NO_ROOT, PYRAMID_NAME, KEEP_MEMOS, MEMO_DIR,
+        ZLIB_LEVEL, CHECKSUM, MAX_CACHED_TILES, CALC_MIN_MAX, HCS, NESTED, OME_META, NO_ROOT, PYRAMID_NAME, KEEP_MEMOS, MEMO_DIR,
         READER_OPTS, OUTPUT_OPTS, EXTRA_READERS, WRITE_METADATA,
         NGFF_VERSION, SHARD_WIDTH, SHARD_HEIGHT, SHARD_DEPTH
     }
@@ -94,6 +94,7 @@ public class CreateNGFF extends BaseTask{
     private static final TextField compressorBloscBlockSize;
     private static final ChoiceBox<String> compressorBloscShuffle;
     private static final TextField compressorZlibLevel;
+    private static final ToggleSwitch checksum;
 
     private static final TextField maxCachedTiles;
     private static final ToggleSwitch disableMinMax;
@@ -494,7 +495,9 @@ public class CreateNGFF extends BaseTask{
                         Type of compression to use with the image.
                         
                         blosc - Fast, lossless compression (recommended)
-                        zlib - Alternative lossless compression
+                        zstd - Alternative fast lossless compression (NGFF 0.5 only)
+                        zlib - Alternative lossless compression (NGFF 0.4 only)
+                        gzip - Alternative lossless compression (NGFF 0.5 only)
                         null/raw - No compression. Will increase file size
                         """
         ));
@@ -842,6 +845,9 @@ public class CreateNGFF extends BaseTask{
                 ""
         );
 
+        checksum = new ToggleSwitch();
+        VBox checksumBox = getSettingContainer(checksum, "Checksum", "Calculate checksums");
+
         compression.getSelectionModel().selectedIndexProperty().addListener(
                 (observableValue, number, number2) -> {
                     compressionPropertiesBox.getChildren().clear();
@@ -854,6 +860,16 @@ public class CreateNGFF extends BaseTask{
                         case zlib -> {
                             compressionPropertiesBox.getChildren().addAll(compressionTitle, zlibLevelBox,
                                     compressionHelpText);
+                            compressionPropertiesBox.setVisible(true);
+                        }
+                        case gzip -> {
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, zlibLevelBox,
+                                    compressionHelpText);
+                            compressionPropertiesBox.setVisible(true);
+                        }
+                        case zstd -> {
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, zlibLevelBox,
+                                    checksumBox, compressionHelpText);
                             compressionPropertiesBox.setVisible(true);
                         }
                         case raw -> compressionPropertiesBox.setVisible(false);
@@ -926,6 +942,15 @@ public class CreateNGFF extends BaseTask{
                 if (compressorZlibLevel.getText() != null)
                     compressionProps.put("level", Integer.parseInt(compressorZlibLevel.getText()));
             }
+            case gzip -> {
+                if (compressorZlibLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorZlibLevel.getText()));
+            }
+            case zstd -> {
+                if (compressorZlibLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorZlibLevel.getText()));
+                compressionProps.put("checksum", String.valueOf(checksum.isSelected()));
+            }
         }
         return compressionProps;
     }
@@ -978,9 +1003,19 @@ public class CreateNGFF extends BaseTask{
                 taskPreferences.putInt(prefKeys.BLOSC_BLOCKSIZE.name(), (Integer) compressionProps.get("blocksize"));
             if (compressionProps.containsKey(prefKeys.BLOSC_SHUFFLE.name()))
                 taskPreferences.put(prefKeys.BLOSC_SHUFFLE.name(), (String) compressionProps.get("shuffle"));
-        } else if (converter.getCompression() == ZarrCompression.zlib) {
-            if (compressionProps.containsKey(prefKeys.ZLIB_LEVEL.name()))
+        } else if (converter.getCompression() == ZarrCompression.zlib ||
+            converter.getCompression() == ZarrCompression.gzip)
+        {
+            if (compressionProps.containsKey(prefKeys.ZLIB_LEVEL.name())) {
                 taskPreferences.putInt(prefKeys.ZLIB_LEVEL.name(), (Integer) compressionProps.get("level"));
+            }
+        } else if (converter.getCompression() == ZarrCompression.zstd) {
+            if (compressionProps.containsKey(prefKeys.ZLIB_LEVEL.name())) {
+                taskPreferences.putInt(prefKeys.ZLIB_LEVEL.name(), (Integer) compressionProps.get("level"));
+            }
+            if (compressionProps.containsKey(prefKeys.CHECKSUM.name())) {
+                taskPreferences.put(prefKeys.CHECKSUM.name(), (String) compressionProps.get("checksum"));
+            }
         }
         taskPreferences.putInt(prefKeys.MAX_CACHED_TILES.name(), converter.getMaxCachedTiles());
 
@@ -1053,6 +1088,11 @@ public class CreateNGFF extends BaseTask{
             compressionProps.put("shuffle", taskPreferences.get(prefKeys.BLOSC_SHUFFLE.name(), "byteshuffle"));
         } else if (converter.getCompression() == ZarrCompression.zlib) {
             compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(),1));
+        } else if (converter.getCompression() == ZarrCompression.gzip) {
+            compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(), 5));
+        } else if (converter.getCompression() == ZarrCompression.zstd) {
+            compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(), 5));
+            compressionProps.put("checksum", taskPreferences.get(prefKeys.CHECKSUM.name(), "true"));
         }
         converter.setCompressionProperties(compressionProps);
 
@@ -1195,6 +1235,14 @@ public class CreateNGFF extends BaseTask{
         } else if (converter.getCompression() == ZarrCompression.zlib) {
             generator.writeFieldName(prefKeys.ZLIB_LEVEL.name());
             generator.writeString(String.valueOf(compressionProps.get("level")));
+        } else if (converter.getCompression() == ZarrCompression.gzip) {
+            generator.writeFieldName(prefKeys.ZLIB_LEVEL.name());
+            generator.writeString(String.valueOf(compressionProps.get("level")));
+        } else if (converter.getCompression() == ZarrCompression.zstd) {
+            generator.writeFieldName(prefKeys.ZLIB_LEVEL.name());
+            generator.writeString(String.valueOf(compressionProps.get("level")));
+            generator.writeFieldName(prefKeys.CHECKSUM.name());
+            generator.writeString(String.valueOf(compressionProps.get("checksum")));
         }
 
         generator.writeFieldName(prefKeys.MAX_CACHED_TILES.name());

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -94,7 +94,9 @@ public class CreateNGFF extends BaseTask{
     private static final TextField compressorBloscClevel;
     private static final TextField compressorBloscBlockSize;
     private static final ChoiceBox<String> compressorBloscShuffle;
-    private static final TextField compressorLevel;
+    private static final TextField compressorZlibLevel;
+    private static final TextField compressorGzipLevel;
+    private static final TextField compressorZstdLevel;
     private static final ToggleSwitch checksum;
 
     private static final TextField maxCachedTiles;
@@ -182,28 +184,14 @@ public class CreateNGFF extends BaseTask{
         } else {
             compressorBloscShuffle.setValue("byteshuffle");
         }
-        switch (converter.getCompression()) {
-            case zlib:
-                if (compressionProps.containsKey("level")) {
-                    compressorLevel.setText(String.valueOf(compressionProps.get("level")));
-                } else {
-                    compressorLevel.setText("1");
-                }
-                break;
-            case gzip:
-                if (compressionProps.containsKey("level")) {
-                    compressorLevel.setText(String.valueOf(compressionProps.get("level")));
-                } else {
-                    compressorLevel.setText("5");
-                }
-                break;
-            case zstd:
-                if (compressionProps.containsKey("level")) {
-                    compressorLevel.setText(String.valueOf(compressionProps.get("level")));
-                } else {
-                    compressorLevel.setText("5");
-                }
-                break;
+        if (compressionProps.containsKey("level")) {
+            compressorZlibLevel.setText(String.valueOf(compressionProps.get("level")));
+            compressorGzipLevel.setText(String.valueOf(compressionProps.get("level")));
+            compressorZstdLevel.setText(String.valueOf(compressionProps.get("level")));
+        } else {
+            compressorZlibLevel.setText("1");
+            compressorGzipLevel.setText("5");
+            compressorZstdLevel.setText("5");
         }
 
         maxCachedTiles.setText(String.valueOf(converter.getMaxCachedTiles()));
@@ -859,10 +847,24 @@ public class CreateNGFF extends BaseTask{
                 ""
         );
 
-        compressorLevel = new TextField();
-        compressorLevel.setTextFormatter(new TextFormatter<>(integerFilterSingleDigit));
-        VBox levelBox = getSettingContainer(
-                compressorLevel,
+        compressorZlibLevel = new TextField();
+        compressorZlibLevel.setTextFormatter(new TextFormatter<>(integerFilterSingleDigit));
+        VBox zlibLevelBox = getSettingContainer(
+                compressorZlibLevel,
+                "level",
+                ""
+        );
+        compressorGzipLevel = new TextField();
+        compressorGzipLevel.setTextFormatter(new TextFormatter<>(integerFilterSingleDigit));
+        VBox gzipLevelBox = getSettingContainer(
+                compressorGzipLevel,
+                "level",
+                ""
+        );
+        compressorZstdLevel = new TextField();
+        compressorZstdLevel.setTextFormatter(new TextFormatter<>(integerFilterSingleDigit));
+        VBox zstdLevelBox = getSettingContainer(
+                compressorZstdLevel,
                 "level",
                 ""
         );
@@ -880,17 +882,17 @@ public class CreateNGFF extends BaseTask{
                             compressionPropertiesBox.setVisible(true);
                         }
                         case zlib -> {
-                            compressionPropertiesBox.getChildren().addAll(compressionTitle, levelBox,
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, zlibLevelBox,
                                     compressionHelpText);
                             compressionPropertiesBox.setVisible(true);
                         }
                         case gzip -> {
-                            compressionPropertiesBox.getChildren().addAll(compressionTitle, levelBox,
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, gzipLevelBox,
                                     compressionHelpText);
                             compressionPropertiesBox.setVisible(true);
                         }
                         case zstd -> {
-                            compressionPropertiesBox.getChildren().addAll(compressionTitle, levelBox,
+                            compressionPropertiesBox.getChildren().addAll(compressionTitle, zstdLevelBox,
                                     checksumBox, compressionHelpText);
                             compressionPropertiesBox.setVisible(true);
                         }
@@ -961,16 +963,16 @@ public class CreateNGFF extends BaseTask{
                     compressionProps.put("shuffle", compressorBloscShuffle.getValue());
             }
             case zlib -> {
-                if (compressorLevel.getText() != null)
-                    compressionProps.put("level", Integer.parseInt(compressorLevel.getText()));
+                if (compressorZlibLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorZlibLevel.getText()));
             }
             case gzip -> {
-                if (compressorLevel.getText() != null)
-                    compressionProps.put("level", Integer.parseInt(compressorLevel.getText()));
+                if (compressorGzipLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorGzipLevel.getText()));
             }
             case zstd -> {
-                if (compressorLevel.getText() != null)
-                    compressionProps.put("level", Integer.parseInt(compressorLevel.getText()));
+                if (compressorZstdLevel.getText() != null)
+                    compressionProps.put("level", Integer.parseInt(compressorZstdLevel.getText()));
                 compressionProps.put("checksum", String.valueOf(checksum.isSelected()));
             }
         }
@@ -1401,17 +1403,17 @@ public class CreateNGFF extends BaseTask{
 
         subject = settings.get(prefKeys.ZLIB_LEVEL.name());
         if (subject != null && compressionSetting == ZarrCompression.zlib) {
-            compressorLevel.setText(subject.textValue());
+            compressorZlibLevel.setText(subject.textValue());
         }
 
         subject = settings.get(prefKeys.GZIP_LEVEL.name());
         if (subject != null && compressionSetting == ZarrCompression.gzip) {
-            compressorLevel.setText(subject.textValue());
+            compressorGzipLevel.setText(subject.textValue());
         }
 
         subject = settings.get(prefKeys.ZSTD_LEVEL.name());
         if (subject != null && compressionSetting == ZarrCompression.zstd) {
-            compressorLevel.setText(subject.textValue());
+            compressorZstdLevel.setText(subject.textValue());
         }
 
         subject = settings.get(prefKeys.MAX_CACHED_TILES.name());

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -245,6 +245,7 @@ public class CreateNGFF extends BaseTask{
         resetConverter();
         int errorCount = 0;
         converter.setLogLevel(logLevel.getValue());
+        converter.setNGFFVersion(ngffVersion.getValue());
         if (!maxWorkers.getText().isEmpty()) converter.setMaxWorkers(Integer.parseInt(maxWorkers.getText()));
         converter.setCompression(compression.getValue());
         if (!tileHeight.getText().isEmpty()) converter.setTileHeight(Integer.parseInt(tileHeight.getText()));
@@ -324,6 +325,7 @@ public class CreateNGFF extends BaseTask{
             return;
         }
         converter.setLogLevel(source.converter.getLogLevel());
+        converter.setNGFFVersion(source.converter.getNGFFVersion());
         converter.setMaxWorkers(source.converter.getMaxWorkers());
         converter.setCompression(source.converter.getCompression());
         converter.setTileHeight(source.converter.getTileHeight());
@@ -336,6 +338,9 @@ public class CreateNGFF extends BaseTask{
         converter.setMinImageSize(source.converter.getMinImageSize());
         converter.setReuseExistingResolutions(source.converter.getReuseExistingResolutions());
         converter.setChunkDepth(source.converter.getChunkDepth());
+        converter.setShardWidth(source.converter.getShardWidth());
+        converter.setShardHeight(source.converter.getShardHeight());
+        converter.setShardDepth(source.converter.getShardDepth());
         converter.setScaleFormat(source.converter.getScaleFormat());
         converter.setAdditionalScaleFormatCSV(source.converter.getAdditionalScaleFormatCSV());
         converter.setFillValue(source.converter.getFillValue());

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -176,10 +176,9 @@ public class CreateNGFF extends BaseTask{
             compressorBloscClevel.setText("5");
         }
         if (compressionProps.containsKey("shuffle")) {
-            // Auto = -1, No = 0, Byte = 1, Bit = 2. So add 1 to get an index for the choicebox
-            compressorBloscShuffle.getSelectionModel().select((int) compressionProps.get("shuffle") + 1);
+            compressorBloscShuffle.setValue((String) compressionProps.get("shuffle"));
         } else {
-            compressorBloscShuffle.getSelectionModel().select(2);
+            compressorBloscShuffle.setValue("byteshuffle");
         }
         if (compressionProps.containsKey("level")) {
             compressorZlibLevel.setText(String.valueOf(compressionProps.get("level")));
@@ -823,7 +822,7 @@ public class CreateNGFF extends BaseTask{
         );
 
         compressorBloscShuffle = new ChoiceBox<>(FXCollections.observableArrayList(
-                "-1 (AUTOSHUFFLE)", "0 (NOSHUFFLE)", "1 (BYTESHUFFLE)", "2 (BITSHUFFLE)"));
+                "noshuffle", "byteshuffle", "bitshuffle"));
         VBox bloscShuffleBox = getSettingContainer(
                 compressorBloscShuffle,
                 "shuffle",
@@ -916,7 +915,7 @@ public class CreateNGFF extends BaseTask{
                     compressionProps.put("blocksize", Integer.parseInt(compressorBloscBlockSize.getText()));
                 // Auto = -1, No = 0, Byte = 1, Bit = 2. So subtract 1 to convert
                 if (compressorBloscShuffle.getValue() != null)
-                    compressionProps.put("shuffle", compressorBloscShuffle.getSelectionModel().getSelectedIndex() - 1);
+                    compressionProps.put("shuffle", compressorBloscShuffle.getValue());
             }
             case zlib -> {
                 if (compressorZlibLevel.getText() != null)
@@ -973,7 +972,7 @@ public class CreateNGFF extends BaseTask{
             if (compressionProps.containsKey(prefKeys.BLOSC_BLOCKSIZE.name()))
                 taskPreferences.putInt(prefKeys.BLOSC_BLOCKSIZE.name(), (Integer) compressionProps.get("blocksize"));
             if (compressionProps.containsKey(prefKeys.BLOSC_SHUFFLE.name()))
-                taskPreferences.putInt(prefKeys.BLOSC_SHUFFLE.name(), (Integer) compressionProps.get("shuffle"));
+                taskPreferences.put(prefKeys.BLOSC_SHUFFLE.name(), (String) compressionProps.get("shuffle"));
         } else if (converter.getCompression() == ZarrCompression.zlib) {
             if (compressionProps.containsKey(prefKeys.ZLIB_LEVEL.name()))
                 taskPreferences.putInt(prefKeys.ZLIB_LEVEL.name(), (Integer) compressionProps.get("level"));
@@ -1046,7 +1045,7 @@ public class CreateNGFF extends BaseTask{
             compressionProps.put("cname", taskPreferences.get(prefKeys.BLOSC_CNAME.name(), "lz4"));
             compressionProps.put("clevel", taskPreferences.getInt(prefKeys.BLOSC_CLEVEL.name(), 5 ));
             compressionProps.put("blocksize", taskPreferences.getInt(prefKeys.BLOSC_BLOCKSIZE.name(), 0));
-            compressionProps.put("shuffle", taskPreferences.getInt(prefKeys.BLOSC_SHUFFLE.name(), 1));
+            compressionProps.put("shuffle", taskPreferences.get(prefKeys.BLOSC_SHUFFLE.name(), "byteshuffle"));
         } else if (converter.getCompression() == ZarrCompression.zlib) {
             compressionProps.put("level", taskPreferences.getInt(prefKeys.ZLIB_LEVEL.name(),1));
         }

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -1465,6 +1465,7 @@ public class CreateNGFF extends BaseTask{
             }).filter(readerClass -> readerClass != null).toList());
         }
         LOGGER.info("Loaded settings for Task %s".formatted(getName()));
+        bindWidgets();
     }
 
     public void resetConverter() {

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.glencoesoftware.bioformats2raw.Converter;
 import com.glencoesoftware.bioformats2raw.Downsampling;
+import com.glencoesoftware.bioformats2raw.SupportedVersions;
 import com.glencoesoftware.bioformats2raw.ZarrCompression;
 import com.glencoesoftware.convert.App;
 import com.glencoesoftware.convert.JobState;
@@ -58,7 +59,8 @@ public class CreateNGFF extends BaseTask{
         COMPACT_DIMENSIONS, DIMENSION_ORDER, DOWNSAMPLING, MIN_IMAGE_SIZE, REUSE_RES, CHUNK_DEPTH, NO_TILES,
         SCALE_FORMAT_STRING, SCALE_FORMAT_CSV, FILL_VALUE, BLOSC_CNAME, BLOSC_CLEVEL, BLOSC_BLOCKSIZE, BLOSC_SHUFFLE,
         ZLIB_LEVEL, MAX_CACHED_TILES, CALC_MIN_MAX, HCS, NESTED, OME_META, NO_ROOT, PYRAMID_NAME, KEEP_MEMOS, MEMO_DIR,
-        READER_OPTS, OUTPUT_OPTS, EXTRA_READERS, WRITE_METADATA
+        READER_OPTS, OUTPUT_OPTS, EXTRA_READERS, WRITE_METADATA,
+        NGFF_VERSION, SHARD_WIDTH, SHARD_HEIGHT, SHARD_DEPTH
     }
 
 
@@ -82,6 +84,10 @@ public class CreateNGFF extends BaseTask{
     private static final TextField scaleFormatString;
     private static final TextField scaleFormatCSV;
     private static final TextField fillValue;
+    private static final ChoiceBox<SupportedVersions> ngffVersion;
+    private static final TextField shardWidth;
+    private static final TextField shardHeight;
+    private static final TextField shardDepth;
     private static final VBox compressionPropertiesBox;
     private static final ChoiceBox<String> compressorBloscCname;
     private static final TextField compressorBloscClevel;
@@ -460,6 +466,9 @@ public class CreateNGFF extends BaseTask{
                 "Detail level of logs to record"
         ));
 
+        ngffVersion = new ChoiceBox<>(FXCollections.observableArrayList(SupportedVersions.values()));
+        standardSettings.add(getSettingContainer(ngffVersion, "NGFF schema version", "NGFF schema version"));
+
         maxWorkers = new TextField();
         maxWorkers.setTextFormatter(new TextFormatter<>(integerFilter));
         standardSettings.add(getSettingContainer(
@@ -586,6 +595,39 @@ public class CreateNGFF extends BaseTask{
                 chunkDepth,
                 "Maximum Chunk Depth",
                 "Maximum chunk depth to read"
+        ));
+
+        shardWidth = new TextField();
+        shardWidth.setTextFormatter(new TextFormatter<>(integerFilter));
+        advancedSettings.add(getSettingContainer(
+                shardWidth,
+                "Shard width",
+                """
+                Maximum shard width (default: 1024). This only applies
+                if the NGFF version is set to 0.5.
+                """
+        ));
+
+        shardHeight = new TextField();
+        shardHeight.setTextFormatter(new TextFormatter<>(integerFilter));
+        advancedSettings.add(getSettingContainer(
+                shardHeight,
+                "Shard height",
+                """
+                Maximum shard height (default: 1024). This only applies
+                if the NGFF version is set to 0.5.
+                """
+        ));
+
+        shardDepth = new TextField();
+        shardDepth.setTextFormatter(new TextFormatter<>(integerFilter));
+        advancedSettings.add(getSettingContainer(
+                shardDepth,
+                "Shard depth",
+                """
+                Maximum shard depth (default: 1). This only applies
+                if the NGFF version is set to 0.5.
+                """
         ));
 
         scaleFormatString = new TextField();
@@ -908,6 +950,11 @@ public class CreateNGFF extends BaseTask{
             taskPreferences.putInt(prefKeys.FILL_VALUE.name(), converter.getFillValue());
         }
 
+        taskPreferences.put(prefKeys.NGFF_VERSION.name(), converter.getNGFFVersion().name());
+        taskPreferences.putInt(prefKeys.SHARD_WIDTH.name(), converter.getShardWidth());
+        taskPreferences.putInt(prefKeys.SHARD_HEIGHT.name(), converter.getShardHeight());
+        taskPreferences.putInt(prefKeys.SHARD_DEPTH.name(), converter.getShardDepth());
+
         Map<String, Object> compressionProps = converter.getCompressionProperties();
         taskPreferences.remove(prefKeys.BLOSC_CNAME.name());
         taskPreferences.remove(prefKeys.BLOSC_CLEVEL.name());
@@ -984,6 +1031,11 @@ public class CreateNGFF extends BaseTask{
         // Scale format CSV not saved
         if (taskPreferences.get(prefKeys.FILL_VALUE.name(), null) != null)
             converter.setFillValue((short) taskPreferences.getInt(prefKeys.FILL_VALUE.name(), 0));
+
+        converter.setNGFFVersion(Enum.valueOf(SupportedVersions.class, taskPreferences.get(prefKeys.NGFF_VERSION.name(), converter.getNGFFVersion().name())));
+        converter.setShardWidth(taskPreferences.getInt(prefKeys.SHARD_WIDTH.name(), converter.getShardWidth()));
+        converter.setShardHeight(taskPreferences.getInt(prefKeys.SHARD_HEIGHT.name(), converter.getShardHeight()));
+        converter.setShardDepth(taskPreferences.getInt(prefKeys.SHARD_DEPTH.name(), converter.getShardDepth()));
 
         Map<String, Object> compressionProps = converter.getCompressionProperties();
         if (converter.getCompression() == ZarrCompression.blosc) {
@@ -1113,6 +1165,15 @@ public class CreateNGFF extends BaseTask{
             generator.writeFieldName(prefKeys.FILL_VALUE.name());
             generator.writeString(String.valueOf(converter.getFillValue()));
         }
+        generator.writeFieldName(prefKeys.NGFF_VERSION.name());
+        generator.writeString(converter.getNGFFVersion().name());
+        generator.writeFieldName(prefKeys.SHARD_WIDTH.name());
+        generator.writeString(String.valueOf(converter.getShardWidth()));
+        generator.writeFieldName(prefKeys.SHARD_HEIGHT.name());
+        generator.writeString(String.valueOf(converter.getShardHeight()));
+        generator.writeFieldName(prefKeys.SHARD_DEPTH.name());
+        generator.writeString(String.valueOf(converter.getShardDepth()));
+
         Map<String, Object> compressionProps = converter.getCompressionProperties();
         if (converter.getCompression() == ZarrCompression.blosc) {
             generator.writeFieldName(prefKeys.BLOSC_CNAME.name());
@@ -1224,6 +1285,18 @@ public class CreateNGFF extends BaseTask{
 
         subject = settings.get(prefKeys.FILL_VALUE.name());
         if (subject != null) fillValue.setText(subject.textValue());
+
+        subject = settings.get(prefKeys.NGFF_VERSION.name());
+        if (subject != null) ngffVersion.setValue(SupportedVersions.valueOf(subject.textValue()));
+
+        subject = settings.get(prefKeys.SHARD_WIDTH.name());
+        if (subject != null) shardWidth.setText(subject.textValue());
+
+        subject = settings.get(prefKeys.SHARD_HEIGHT.name());
+        if (subject != null) shardHeight.setText(subject.textValue());
+
+        subject = settings.get(prefKeys.SHARD_DEPTH.name());
+        if (subject != null) shardDepth.setText(subject.textValue());
 
         subject = settings.get(prefKeys.BLOSC_CNAME.name());
         if (subject != null) compressorBloscCname.setValue(subject.textValue());

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateNGFF.java
@@ -1169,7 +1169,7 @@ public class CreateNGFF extends BaseTask{
                     LOGGER.error("Did not find class for extra reader " + s);
                     return null;
                 }
-            }).toList());
+            }).filter(readerClass -> readerClass != null).toList());
         }
         // Warn users if outdated settings were loaded
         if (!userWarned
@@ -1462,7 +1462,7 @@ public class CreateNGFF extends BaseTask{
                     LOGGER.error("Did not find class for extra reader " + s);
                     return null;
                 }
-            }).toList());
+            }).filter(readerClass -> readerClass != null).toList());
         }
         LOGGER.info("Loaded settings for Task %s".formatted(getName()));
     }

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
@@ -136,7 +136,7 @@ public class CreateTiff extends BaseTask {
             LOGGER.info("TIFF creation successful");
         } catch (Exception e) {
             this.status = JobState.status.FAILED;
-            LOGGER.error("TIFF creation failed - " + e);
+            LOGGER.error("TIFF creation failed", e);
             parent.statusText = "Job Failed: " + e;
         } finally {
             listener.stop();

--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
@@ -105,6 +105,7 @@ public class CreateTiff extends BaseTask {
         } else {
             converter.setCompressionOptions(null);
         }
+        converter.setOverwrite(overwrite);
         // This task doesn't have settings which can fail to be set
         return 0;
     }
@@ -130,7 +131,6 @@ public class CreateTiff extends BaseTask {
         LOGGER.info("Running raw2ometiff");
         this.status = JobState.status.RUNNING;
         try {
-            if (!overwrite && output.exists()) throw new IOException("Output path already exists");
             converter.call();
             this.status = JobState.status.COMPLETED;
             LOGGER.info("TIFF creation successful");


### PR DESCRIPTION
~Untested so far, just opening a draft to get a proper build.~ This adds Zarr v3/OME-Zarr 0.5 support, which includes upgrades to the latest versions of Bio-Formats/bioformats2raw/raw2ometiff. As described in comments below, conversion to OME-Zarr (0.4 and 0.5) and OME-TIFF has been tested across a variety of scenarios including different compression, chunk, and shard options.