### PR TITLE
Review of Gradle repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ applicationName = 'NGFF-Converter'
 repositories {
     mavenLocal()
     mavenCentral()
-
     maven {
         url 'https://repo.glencoesoftware.com/repository/bioformats2raw2ometiff/'
     }
@@ -26,7 +25,7 @@ repositories {
         url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases/'
     }
     maven {
-        url 'https://maven.scijava.org/content/groups/public'
+        url 'https://artifacts.glencoesoftware.com/artifactory/scijava-thirdparty'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ repositories {
     maven {
         url 'https://artifacts.glencoesoftware.com/artifactory/scijava-thirdparty'
     }
+    maven {
+        url 'https://artifacts.glencoesoftware.com/artifactory/unidata-releases'
+    }
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,6 @@ repositories {
         url 'https://repo.glencoesoftware.com/repository/bioformats2raw2ometiff/'
     }
     maven {
-        url 'https://nexus.senbox.net/nexus/content/groups/public/'
-    }
-    maven {
         url 'https://artifacts.glencoesoftware.com/artifactory/ome.releases/'
     }
     maven {


### PR DESCRIPTION
While trying to regenerate artifacts for evaluating #89, I came across the fact that maven.scijava.org is unavailable for the second time in a few weeks (https://github.com/glencoesoftware/NGFF-Converter/actions/runs/26442080722).

To unblock current and future work on this application, this PR reviews and updates the list of repositories declared in `build.gradle` and adopts similar conventions as `bioformats2raw/raw2ometiff`:

- https://nexus.senbox.net which was used for fetching the historical `jzarr` artifacts is removed. Both the latest `jzarr` releases and the `zarr-java` releases (for #89) are deployed to Maven Central which is already declared in the repositories list
- https://maven.scijava.org is removed in favor of our mirrors of the Scijava third-party repository (for JHDF5) and the Unidata repositories (for NetCDF Java)