### PR TITLE
Allow special characters in input file to propagate to output file name

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/tasks/BaseTask.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/BaseTask.java
@@ -19,7 +19,6 @@ import javafx.scene.layout.*;
 import javafx.scene.text.TextAlignment;
 import javafx.stage.DirectoryChooser;
 import javafx.stage.FileChooser;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.kordamp.ikonli.javafx.FontIcon;
 import org.slf4j.LoggerFactory;
@@ -69,7 +68,11 @@ public abstract class BaseTask {
 
     public void setInput(File input){
         this.input = input;
-        this.outputName = FilenameUtils.getBaseName(input.getAbsolutePath());
+        this.outputName = input.getAbsoluteFile().getName();
+        int dot = this.outputName.lastIndexOf(".");
+        if (dot > 0) {
+          this.outputName = this.outputName.substring(0, dot);
+        }
     }
 
     // Get status as a string for display

--- a/src/main/java/com/glencoesoftware/convert/tasks/Output.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/Output.java
@@ -40,6 +40,11 @@ import java.util.prefs.Preferences;
 // Virtual task to allow configuration of the output file destination and other misc options
 public class Output extends BaseTask {
 
+    private static final String REPLACEMENT = "_";
+    private static final String[] INVALID = new String[] {
+      "/", "\\\\"
+    };
+
     public static final String name = "Output";
     public static final Preferences taskPreferences = Preferences.userRoot().node(name);
     public enum prefKeys {OVERWRITE, DIRECT_WRITE, LOG_CHOICE, LOG_LOCATION,
@@ -122,9 +127,16 @@ public class Output extends BaseTask {
 
     public void applyOutputToWidgets() {
         outputDirectory.setText(this.output.getParent());
-        outputFileName.setText(this.output.getName());
+        String sanitizedName = sanitizeFileName(this.output.getName());
+        outputFileName.setText(sanitizedName);
         if (parent.firstInput.getParent().equals(this.output.getParent())) outputChoice.setValue(outputLocationType.INPUT_FOLDER);
         else outputChoice.setValue(outputLocationType.CUSTOM_FOLDER);
+    }
+
+    @Override
+    public void setInput(File input) {
+      super.setInput(input);
+      outputName = sanitizeFileName(outputName);
     }
 
     public void setOutputFromWidgets() {
@@ -133,14 +145,20 @@ public class Output extends BaseTask {
         String fileName = outputFileName.getText();
         String extension = parent.getOutputExtension();
         // User cleared a custom name
-        if (fileName.isEmpty()) fileName = input.getName();
-        else if (!fileName.toLowerCase().endsWith(extension)) {
-            fileName += extension;
-            outputFileName.setText(fileName);
+        if (fileName.isEmpty()) {
+            fileName = input.getName();
         }
-        if (outputChoice.getValue() == outputLocationType.INPUT_FOLDER)
+        if (!fileName.toLowerCase().endsWith(extension)) {
+            fileName += extension;
+        }
+        fileName = sanitizeFileName(fileName);
+        outputFileName.setText(fileName);
+        if (outputChoice.getValue() == outputLocationType.INPUT_FOLDER) {
             this.output = new File(parent.firstInput.getParent(), fileName);
-        else this.output = new File(outputDirectory.getText(), fileName);
+        }
+        else {
+            this.output = new File(outputDirectory.getText(), fileName);
+        }
     }
 
     public void prepareForDisplay() {
@@ -157,7 +175,7 @@ public class Output extends BaseTask {
     // Attach this instance to the static widgets
     private void bindWidgets() {
         // This File chooser in particular is instance-specific
-        fileResetButton.onMouseClickedProperty().set(e -> outputFileName.setText(input.getName()));
+        fileResetButton.onMouseClickedProperty().set(e -> outputFileName.setText(sanitizeFileName(input.getName())));
 
         fileBrowseButton.onMouseClickedProperty().set(e -> {
                     FileChooser fileChooser = new FileChooser();
@@ -171,7 +189,7 @@ public class Output extends BaseTask {
                             outputChoice.getSelectionModel().select(0);
                         else outputChoice.getSelectionModel().select(1);
                         outputDirectory.setText(selectedFile.getParent());
-                        outputFileName.setText(selectedFile.getName());
+                        outputFileName.setText(sanitizeFileName(selectedFile.getName()));
                     }
                 });
     }
@@ -414,7 +432,8 @@ public class Output extends BaseTask {
         HBox.setHgrow(outputFileName, Priority.ALWAYS);
         fileNameWidget.setAlignment(Pos.CENTER_LEFT);
 
-        outputFileNameContainer = getSettingContainer(fileNameWidget, "File name", "");
+        outputFileNameContainer = getSettingContainer(fileNameWidget, "File name",
+          "Invalid characters ('/', '\\'), will be automatically replaced with '_'");
         outputChoiceContainer = getSettingContainer(outputChoice, "Location", "");
 
         HBox outputDirWidget = getDirectorySelectWidget(outputDirectory, "Choose output directory", null);
@@ -679,5 +698,13 @@ public class Output extends BaseTask {
         if (subject != null) workingDirectoryField.setText(subject.textValue());
 
         LOGGER.info("Loaded settings for Task %s".formatted(getName()));
+    }
+
+    private String sanitizeFileName(String name) {
+      String rtn = new String(name);
+      for (String c : INVALID) {
+        rtn = rtn.replaceAll(c, REPLACEMENT);
+      }
+      return rtn;
     }
 }

--- a/src/main/java/com/glencoesoftware/convert/tasks/Output.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/Output.java
@@ -42,7 +42,7 @@ public class Output extends BaseTask {
 
     private static final String REPLACEMENT = "_";
     private static final String[] INVALID = new String[] {
-      "/", "\\\\"
+      "/", "\\\\", ":"
     };
 
     public static final String name = "Output";


### PR DESCRIPTION
This was flagged during testing of #89, but the issue noted was also reproducible with 2.1.0.

When the input file name contains certain special characters (in particular `\`), everything prior to and including that character was removed from the output file name. The conversion does succeed, but with an unexpected output file name.

The output file name is visible prior to conversion by adding a job, then clicking the gear icon, and then clicking the right arrow at the top of the settings dialog until the `Output` settings are visible.

The behavior observed with 2.1.0 and #89 is consistent with use of `FilenameUtils.getBaseName(...)`:

https://commons.apache.org/proper/commons-io/apidocs/org/apache/commons/io/FilenameUtils.html#getBaseName(java.lang.String)

which states that `The text after the last forward or backslash and before the last period is returned.`

The proposed change should preserve the input file name, including all special characters. However, I have mixed feelings about whether this is actually a good idea. The presence of characters such as `\` and `/` (which on Mac OS X is actually `:` if you look at `ls` output instead of Finder) can cause plenty of problems with downstream processing. I am a bit hesitant to encourage propagation of `\` and `/` in file names, rather than omitting or replacing these characters with something else (e.g. `_`). Additionally, the output file name can be set by the user, independent of what is preset in the `Output` task settings.

I do not necessarily expect this to be merged as-is, but am opening for discussion so that we can agree on the best strategy here. cc @sbesson @erindiel @Yajing826 @mabruce @muhanadz 