### PR TITLE
Allow running `bin/NGFF-Converter` on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,3 +174,9 @@ downloadLicenses {
         (license('The MIT License', 'https://opensource.org/license/mit/')) : ['MIT License', 'MIT']
     ]
 }
+
+startScripts {
+  doLast {
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%\\\\lib\\\\*')
+  }
+}


### PR DESCRIPTION
Mostly for development testing prior to opening pull requests.

Matches what we already have in bioformats2raw/raw2ometiff, see https://github.com/glencoesoftware/bioformats2raw/pull/202. This shouldn't impact anyone who is using prebuilt packages (i.e. not running `bin/NGFF-Converter`) or anyone who is not using Windows.