### PR TITLE
Fix overwriting OME-TIFF output

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
@@ -121,6 +121,7 @@ public class CreateTiff extends BaseTask {
 
     public void setOverwrite(boolean shouldOverwrite) {
         overwrite = shouldOverwrite;
+        converter.setOverwrite(shouldOverwrite);
     }
 
     public void run() {


### PR DESCRIPTION
This fixes overwriting OME-TIFF output when the choice to overwrite was imported from a settings file and not manually toggled on (as reported by @muhanadz).

This is now consistent with the behavior of `setOverwrite` in the `CreateNGFF` task.