### PR TITLE
Remove bundling of blosc library in the package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startswith(github.ref, 'refs/tags/')
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: List artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,15 +39,6 @@ jobs:
         architecture: 'x64'
     - name: Setup Gradle wrapper
       uses: gradle/actions/setup-gradle@v6
-    - if: ${{ matrix.os == 'macos-latest' }}
-      name: Install bundler and download blosc
-      run: |
-        brew install dylibbundler
-        curl -J -O -k -L 'https://github.com/glencoesoftware/c-blosc-macos-x86_64/releases/download/20220919/libblosc.dylib'
-    - if: ${{ matrix.os == 'windows-latest' }}
-      name: Download blosc
-      run: |
-        c:\msys64\usr\bin\wget.exe 'https://github.com/glencoesoftware/c-blosc-windows-x86_64/releases/download/20220919/blosc.dll'
     - if: ${{ matrix.os == 'windows-latest' }}
       name: Run jpackage with Gradle (installer)
       run: ./gradlew jpackage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
     if: startswith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: List artifacts

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NGFF-Converter is an open source tool for converting bioimage formats to the [OME-TIFF](https://ome-model.readthedocs.io/en/stable/ome-tiff/) and [OME-Zarr](https://ngff.openmicroscopy.org/) specifications.
 
-Formats [supported by the bio-formats library](https://bio-formats.readthedocs.io/en/stable/supported-formats.html) should be able to be converted by this tool. 
+Formats [supported by the Bio-formats library](https://bio-formats.readthedocs.io/en/stable/supported-formats.html) should be able to be converted by this tool.
 Internally NGFF-Converter uses the [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) and [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff) packages for conversion.
 With default settings, the resulting files should automatically have resolution pyramids generated if needed.
 
@@ -10,13 +10,14 @@ Release notes detailing changes between versions can be found [here](https://git
 
 NGFF-Converter is [not supported on Linux](https://github.com/glencoesoftware/NGFF-Converter/issues/74#issuecomment-3131337548). To convert files on Linux, please use the [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) and [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff) command line tools.
 
-## Prebuilt Binaries
+## Installation
 
-NGFF-Converter releases can be downloaded here:
+Pre-built signed Windows and MacOS artifacts can be downloaded for the latest NGFF-Converter release here:
 
 [<img src="https://img.shields.io/badge/Downloads_Page-2980B8?style=flat" height="35"  alt="Downloads Page"/>](https://downloads.glencoesoftware.com/public/NGFF-Converter/latest/)
 
 ### Known issues:
+
 * The underlying bioformats package is currently unable to read some formats on ARM-based MacOS systems.
 
 ## Usage
@@ -55,10 +56,26 @@ steps. The "help" icon next to each setting provides warnings about particularly
 
 If you need further help, please feel free to [raise an issue](https://github.com/glencoesoftware/NGFF-Converter/issues).
 
-## License
-NGFF-converter is distributed under the terms of the GPL license. Please see LICENSE.txt for further details.
+## Development
 
-## Build and run:
+### Dependencies
+
+NGFF-Converter has the following requirements/dependencies:
+
+- Java 17+
+- JavaFX
+- [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw)
+- [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff)
+
+See [build.gradle](build.gradle) for more precise versioning.
+
+### Building from source
+
+Clone the repository:
+
+    git clone https://github.com/glencoesoftware/NGFF-Converter
+
+Run the build command:
 
     ./gradlew clean build
     cd build/distributions
@@ -66,30 +83,10 @@ NGFF-converter is distributed under the terms of the GPL license. Please see LIC
     cd NGFF-Converter-0.1-SNAPSHOT
     ./bin/NGFF-Converter
 
-### Dependencies
-NGFF-Converter has the following requirements/dependencies:
-- Java 16+
-- JavaFX
-- [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw)
-- [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff)
+## License
 
-See `build.gradle` for more precise versioning.
-
-### Windows & MacOS
-Download prebuilt, signed binaries for these platforms [here](https://www.glencoesoftware.com/products/ngff-converter/).
-
-### Ubuntu
-Running from source is possible via the following steps:
-
-Install openjdk-17
-
-    sudo apt install openjdk-17-jdk
-    
-Install the blosc dependency
-
-    sudo apt-get install libblosc-dev
-
-Clone and run the repo
+NGFF-converter is distributed under the terms of the GPL license.
+Please see [LICENSE.txt](LICENSE.txt) for further details.
 
 ## Project skeleton created using a combination of:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NGFF-Converter is an open source tool for converting bioimage formats to the [OME-TIFF](https://ome-model.readthedocs.io/en/stable/ome-tiff/) and [OME-Zarr](https://ngff.openmicroscopy.org/) specifications.
 
-Formats [supported by the Bio-formats library](https://bio-formats.readthedocs.io/en/stable/supported-formats.html) should be able to be converted by this tool.
+Formats [supported by the Bio-Formats library](https://bio-formats.readthedocs.io/en/stable/supported-formats.html) should be able to be converted by this tool.
 Internally NGFF-Converter uses the [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) and [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff) packages for conversion.
 With default settings, the resulting files should automatically have resolution pyramids generated if needed.
 
@@ -85,7 +85,7 @@ Run the build command:
 
 ## License
 
-NGFF-converter is distributed under the terms of the GPL license.
+NGFF-Converter is distributed under the terms of the GPL license.
 Please see [LICENSE.txt](LICENSE.txt) for further details.
 
 ## Project skeleton created using a combination of:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ NGFF-Converter has the following requirements/dependencies:
 - JavaFX
 - [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw)
 - [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff)
-- [blosc](https://github.com/Blosc/c-blosc)
 
 See `build.gradle` for more precise versioning.
 

--- a/build.gradle
+++ b/build.gradle
@@ -89,34 +89,6 @@ runtime {
 
     def currentOs = org.gradle.internal.os.OperatingSystem.current()
 
-    tasks.jpackageImage.doLast {
-        if(currentOs.windows) {
-            assert file("blosc.dll").exists()
-            copy {
-                from "blosc.dll"
-                into("$buildDir/jpackage/$applicationName/app")
-            }
-        } else if(currentOs.macOsX) {
-            // Add blosc to the image
-            assert file("libblosc.dylib").exists()
-            copy {
-                from "libblosc.dylib"
-                into("$buildDir/jpackage/${applicationName}.app/Contents/lib")
-            }
-            // Tell the app where to find it
-            exec {
-                commandLine 'install_name_tool', '-add_rpath', '@executable_path/../lib', "$buildDir/jpackage/${applicationName}.app/Contents/MacOS/${applicationName}"
-            }
-            // Fix the permissions
-            exec {
-                commandLine 'dylibbundler', '-cd', '-of', '-b', '-x', "$buildDir/jpackage/${applicationName}.app/Contents/MacOS/${applicationName}", '-d', "$buildDir/jpackage/${applicationName}.app/Contents/lib", '-p', '@executable_path/../lib', '-s', "$buildDir/../lib"
-            }
-        } else {
-            throw new Exception("Unsupported Operating System")
-        }
-    }
-
-
     launcher {
         noConsole = true
     }


### PR DESCRIPTION
See also https://github.com/glencoesoftware/bioformats2raw/pull/324 and https://github.com/glencoesoftware/raw2ometiff/pull/158

With the migration to `zarr-java`, pre-compiled `blosc` libraries are shipped with the `blosc-java` dependency for different platforms/architectures. This PR removes the special build steps that were previously bundling the library in the package. The README is also updated accordingly and the development section is cleaned up.

This PR should be tested against the various supported platforms (MacOS and Windows primarily) by converting any sample file to OME-Zarr, version 0.4 or 0.5, using the default compression options (which should be set to `blosc`) and validating the operation completes successfully.