### PR TITLE
Fix type of `MAX_WORKERS` field when importing settings for OME-TIFF job

### DIFF
--- a/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
+++ b/src/main/java/com/glencoesoftware/convert/tasks/CreateTiff.java
@@ -361,7 +361,7 @@ public class CreateTiff extends BaseTask {
         if (subject != null) logLevel.setValue(subject.textValue());
 
         subject = settings.get(prefKeys.MAX_WORKERS.name());
-        if (subject != null) maxWorkers.setText(String.valueOf(subject.intValue()));
+        if (subject != null) maxWorkers.setText(subject.textValue());
 
         subject = settings.get(prefKeys.COMPRESSION.name());
         if (subject != null) compression.setValue(CompressionType.valueOf(subject.textValue()));


### PR DESCRIPTION
Exported settings for the OME-TIFF job contain something like:

```
{
  "Version": "2.2.0",
  "Convert to TIFF": {
    "LOG_LEVEL": "DEBUG",
    "MAX_WORKERS": "4"
   }
}
```

Changing the max workers field in the OME-TIFF job options panel to something else, then attempting to load the exported settings does not change the max workers (without this change). With this change, importing settings should work as expected.

I debated enforcing an integer type for this field, but that would mean that existing exported settings would still not import correctly.